### PR TITLE
[2단계 - 페이먼츠 모듈] 헤인(방세린) 미션 제출합니다.

### DIFF
--- a/components/.prettierrc
+++ b/components/.prettierrc
@@ -1,12 +1,12 @@
 {
-	"singleQuote": true,
-	"semi": true,
-	"useTabs": false,
-	"tabWidth": 2,
-	"trailingComma": "all",
-	"printWidth": 80,
-	"bracketSpacing": true,
-	"arrowParens": "always",
-	"endOfLine": "auto",
-	"prefer-const": true
+  "singleQuote": true,
+  "semi": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "auto",
+  "prefer-const": true
 }

--- a/components/.storybook/main.ts
+++ b/components/.storybook/main.ts
@@ -1,20 +1,21 @@
-import type { StorybookConfig } from "@storybook/react-vite";
+import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
-    "@storybook/addon-onboarding",
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@chromatic-com/storybook",
-    "@storybook/addon-interactions",
+    '@storybook/addon-onboarding',
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
   ],
   framework: {
-    name: "@storybook/react-vite",
+    name: '@storybook/react-vite',
     options: {},
   },
   docs: {
-    autodocs: "tag",
+    autodocs: true,
+    defaultName: 'Documentation',
   },
 };
 export default config;

--- a/components/.storybook/preview.ts
+++ b/components/.storybook/preview.ts
@@ -1,7 +1,18 @@
+import {
+  INITIAL_VIEWPORTS,
+  MINIMAL_VIEWPORTS,
+} from '@storybook/addon-viewport';
+
 import type { Preview } from '@storybook/react';
 
 const preview: Preview = {
   parameters: {
+    viewport: {
+      viewports: {
+        ...MINIMAL_VIEWPORTS,
+        ...INITIAL_VIEWPORTS,
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/components/README.md
+++ b/components/README.md
@@ -14,6 +14,8 @@ npm install hain-tain-components
 
 ### Quick start
 
+- **Modal**
+
 ```js
 import React, { useState } from 'react';
 
@@ -62,12 +64,124 @@ function App() {
 export default App;
 ```
 
+- **AlertModal**
+
+```js
+import { AlertModal, Button, useModal } from 'hain-tain-components';
+import React from 'react';
+
+const UsageAlertModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+
+  return (
+    <>
+      <Button
+        text="open AlertModal"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <AlertModal
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="AlertModal"
+        content="This is a modal for notifications. There is only a confirmation button."
+        handleConfirm={() => {
+          alert('Confirm');
+        }}
+      ></AlertModal>
+    </>
+  );
+};
+
+export default UsageAlertModal;
+```
+
+- **ConfirmModal**
+
+```js
+import { ConfirmModal, Button, useModal } from 'hain-tain-components';
+import React from 'react';
+
+const UsageConfirmModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+
+  return (
+    <>
+      <Button
+        text="open ConfirmModal"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <ConfirmModal
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="ConfirmModal"
+        content="This is a modal for confirmation. There is a Cancel button and a Confirm button."
+        handleConfirm={() => {
+          alert('Confirm');
+        }}
+      ></ConfirmModal>
+    </>
+  );
+};
+
+export default UsageConfirmModal;
+```
+
+- **PromptModal**
+
+```js
+import { Button } from '../lib';
+import PromptModal from '../lib/Modal/PromptModal/PromptModal';
+import React from 'react';
+import useInput from '../lib/hooks/useInput';
+import useModal from '../lib/hooks/useModal';
+
+const UsagePromptModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+  const { value, handleChange, resetValue } = useInput();
+
+  return (
+    <>
+      <Button
+        text="open PromptModal"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <PromptModal
+        value={value}
+        onChange={handleChange}
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="PromptModal"
+        content="This is a modal for receiving input from the user. Setting the value(state) for input is required."
+        handleConfirm={() => {
+          alert(`Confirm\nvalue: ${value}`);
+          resetValue();
+        }}
+      ></PromptModal>
+    </>
+  );
+};
+
+export default UsagePromptModal;
+```
+
 ### API
 
 #### Top-Level Exports
 
 - `Button`
 - `Modal`
+- `AlertModal`
+- `ConfirmModal`
+- `PromptModal`
+
+- `useInput`
+- `useModal`
 
 #### `<Button>`
 
@@ -86,20 +200,93 @@ export default App;
 
 ##### props
 
-| props                        | type                                        | description                                                             |
-| ---------------------------- | ------------------------------------------- | ----------------------------------------------------------------------- |
-| `isOpened`                   | boolean                                     | Determines whether the modal is displayed.                              |
-| `onClose`                    | Function                                    | The function called when the modal is closed.                           |
-| `zIndex` (optional)          | number (`0`: default)                       | The number setting for the modal's z-index.                             |
-| `title` (optional)           | string                                      | The text displayed at the top of the modal.                             |
-| `description` (optional)     | string                                      | The text displayed in the middle of the modal.                          |
-| `children` (optional)        | JSX.Element                                 | The element displayed in the middle of the modal.                       |
-| `modalPosition` (optional)   | ModalPosition(`center` : default, `bottom`) | The position of the modal within the window.                            |
-| `primaryButton` (optional)   | {text:string, style:ButtonStyle }           | The primary button at the bottom of the modal.                          |
-| `secondaryButton` (optional) | {text:string, style:ButtonStyle }           | The secondary button at the bottom of the modal.                        |
-| `buttonPosition` (optional)  | ButtonPosition(`row` : default, `column`)   | The layout orientation of the buttons at the bottom of the modal.       |
-| `primaryColor` (optional)    | string (`#333333` : default)                | The primary color used for the buttons.                                 |
-| `showCloseButton` (optional) | boolean (`false` : default)                 | Determines whether a close button is displayed at the top of the modal. |
+| props                             | type                                                     | description                                                             |
+| --------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `isOpened`                        | boolean                                                  | Determines whether the modal is displayed.                              |
+| `closeModal`                      | Function                                                 | The function called when the modal is closed.                           |
+| `size` (optional)                 | ModalSize (`small`, `medium`, `large` : default )        | Determine the size of the modal                                         |
+| `title` (optional)                | string                                                   | The text displayed at the top of the modal.                             |
+| `description` (optional)          | string                                                   | The text displayed in the middle of the modal.                          |
+| `children` (optional)             | JSX.Element                                              | The element displayed in the middle of the modal.                       |
+| `modalPosition` (optional)        | ModalPosition(`center` : default, `bottom`)              | The position of the modal within the window.                            |
+| `primaryButton` (optional)        | {text:string, style:ButtonStyle }                        | The primary button at the bottom of the modal.                          |
+| `secondaryButton` (optional)      | {text:string, style:ButtonStyle }                        | The secondary button at the bottom of the modal.                        |
+| `buttonPosition` (optional)       | ButtonPosition(`row` : default, `column`)                | The layout orientation of the buttons at the bottom of the modal.       |
+| `buttonJustifyContent` (optional) | ButtonJustifyContent(`center`: default ,`left`, `right`) | Determine the location layout of the buttons                            |
+| `primaryColor` (optional)         | string (`#333333` : default)                             | The primary color used for the buttons.                                 |
+| `showCloseButton` (optional)      | boolean (`false` : default)                              | Determines whether a close button is displayed at the top of the modal. |
+
+#### `<AlertModal>`
+
+##### props
+
+| props                             | type                                                     | description                                             |
+| --------------------------------- | -------------------------------------------------------- | ------------------------------------------------------- |
+| `isOpened`                        | boolean                                                  | Determines whether the modal is displayed.              |
+| `closeModal`                      | Function                                                 | The function called when the modal is closed.           |
+| `handleConfirm`(optional)         | Function                                                 | The function called when the confirm button is pressed. |
+| `size` (optional)                 | ModalSize (`small`, `medium`, `large` : default )        | Determine the size of the modal.                        |
+| `title` (optional)                | string                                                   | The text displayed at the top of the modal.             |
+| `description` (optional)          | string                                                   | The text displayed in the middle of the modal.          |
+| `content` (optional)              | string                                                   | The main text displayed in the middle of the modal.     |
+| `children` (optional)             | JSX.Element                                              | The element displayed in the middle of the modal.       |
+| `modalPosition` (optional)        | ModalPosition(`center` : default, `bottom`)              | The position of the modal within the window.            |
+| `buttonJustifyContent` (optional) | ButtonJustifyContent(`center` ,`left`, `right`: default) | Determine the location layout of the buttons.           |
+| `primaryColor` (optional)         | string (`#333333` : default)                             | The primary color used for the buttons.                 |
+
+#### `<ConfirmModal>`
+
+##### props
+
+| props                             | type                                                     | description                                             |
+| --------------------------------- | -------------------------------------------------------- | ------------------------------------------------------- |
+| `isOpened`                        | boolean                                                  | Determines whether the modal is displayed.              |
+| `closeModal`                      | Function                                                 | The function called when the modal is closed.           |
+| `handleConfirm`(optional)         | Function                                                 | The function called when the confirm button is pressed. |
+| `size` (optional)                 | ModalSize (`small`, `medium`, `large` : default )        | Determine the size of the modal.                        |
+| `title` (optional)                | string                                                   | The text displayed at the top of the modal.             |
+| `description` (optional)          | string                                                   | The text displayed in the middle of the modal.          |
+| `content` (optional)              | string                                                   | The main text displayed in the middle of the modal.     |
+| `children` (optional)             | JSX.Element                                              | The element displayed in the middle of the modal.       |
+| `modalPosition` (optional)        | ModalPosition(`center` : default, `bottom`)              | The position of the modal within the window.            |
+| `buttonJustifyContent` (optional) | ButtonJustifyContent(`center` ,`left`, `right`: default) | Determine the location layout of the buttons.           |
+| `primaryColor` (optional)         | string (`#333333` : default)                             | The primary color used for the buttons.                 |
+
+#### `<PromptModal>`
+
+##### props
+
+| props                             | type                                                     | description                                                                      |
+| --------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `isOpened`                        | boolean                                                  | Determines whether the modal is displayed.                                       |
+| `closeModal`                      | Function                                                 | The function called when the modal is closed.                                    |
+| `value`                           | string                                                   | state of input.                                                                  |
+| `onChange`                        | (e: React.ChangeEvent<HTMLInputElement>) => void         | Update the value state with a function that runs when the onchange event occurs. |
+| `handleConfirm`(optional)         | Function                                                 | The function called when the confirm button is pressed.                          |
+| `labelText` (optional)            | string                                                   | Text in the label.                                                               |
+| `labelPosition` (optional)        | LabelPosition ("row" : default , "column" )              | Layout position of the label.                                                    |
+| `placeholder` (optional)          | string                                                   | input placeholder.                                                               |
+| `size` (optional)                 | ModalSize (`small`, `medium`, `large` : default )        | Determine the size of the modal.                                                 |
+| `title` (optional)                | string                                                   | The text displayed at the top of the modal.                                      |
+| `description` (optional)          | string                                                   | The text displayed in the middle of the modal.                                   |
+| `content` (optional)              | string                                                   | The main text displayed in the middle of the modal.                              |
+| `children` (optional)             | JSX.Element                                              | The element displayed in the middle of the modal.                                |
+| `modalPosition` (optional)        | ModalPosition(`center` : default, `bottom`)              | The position of the modal within the window.                                     |
+| `buttonJustifyContent` (optional) | ButtonJustifyContent(`center` ,`left`, `right`: default) | Determine the location layout of the buttons.                                    |
+| `primaryColor` (optional)         | string (`#333333` : default)                             | The primary color used for the buttons.                                          |
+
+#### `<Input>`
+
+##### props
+
+| props                      | type                                             | description                                                                      |
+| -------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `value`                    | string                                           | state of input.                                                                  |
+| `onChange`                 | (e: React.ChangeEvent<HTMLInputElement>) => void | Update the value state with a function that runs when the onchange event occurs. |
+| `labelText` (optional)     | string                                           | Text in the label.                                                               |
+| `labelPosition` (optional) | LabelPosition ("row" : default , "column" )      | Layout position of the label.                                                    |
+| `placeholder` (optional)   | string                                           | input placeholder.                                                               |
+| `primaryColor` (optional)  | string (`#333333` : default)                     | The primary color.                                                               |
 
 ### Contributors
 

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hain-tain-components",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hain-tain-components",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hain-tain-components",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "This is a module created for practice",
   "type": "module",
   "types": "dist/index.d.ts",

--- a/components/src/App.tsx
+++ b/components/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import React from 'react';
 import UsageAlertModal from '../src/usage/UsageAlertModal';
 import UsageConfirmModal from '../src/usage/UsageConfirmModal';
+import UsageCustomModal from './usage/UsageCustomModal';
 import UsageModal from '../src/usage/UsageModal';
 import UsagePromptModal from '../src/usage/UsagePromptModal';
 import styled from 'styled-components';
@@ -14,6 +15,7 @@ function App() {
       <UsageAlertModal />
       <UsageConfirmModal />
       <UsagePromptModal />
+      <UsageCustomModal />
     </StyledContainer>
   );
 }

--- a/components/src/App.tsx
+++ b/components/src/App.tsx
@@ -25,6 +25,7 @@ function App() {
         closeModal={handleClose}
         title="안녕하세요, 하루 💙"
         description="여기는 description 이에요."
+        size="small"
         children={
           <>
             <div style={{ backgroundColor: '#f3e3da', height: '100px' }}>

--- a/components/src/App.tsx
+++ b/components/src/App.tsx
@@ -1,50 +1,27 @@
 import './App.css';
 
-import React, { useState } from 'react';
-
-import Button from './lib/Button/Button';
-import Modal from './lib/Modal/Modal';
+import React from 'react';
+import UsageAlertModal from '../src/usage/UsageAlertModal';
+import UsageConfirmModal from '../src/usage/UsageConfirmModal';
+import UsageModal from '../src/usage/UsageModal';
+import UsagePromptModal from '../src/usage/UsagePromptModal';
+import styled from 'styled-components';
 
 function App() {
-  const [isOpened, setIsOpened] = useState(false);
-
-  const handleClose = () => {
-    setIsOpened(false);
-  };
-
   return (
-    <>
-      <Button
-        text="모달 열기"
-        onClick={() => {
-          setIsOpened(true);
-        }}
-      />
-      <Modal
-        isOpened={isOpened}
-        closeModal={handleClose}
-        title="안녕하세요, 하루 💙"
-        description="여기는 description 이에요."
-        size="small"
-        children={
-          <>
-            <div style={{ backgroundColor: '#f3e3da', height: '100px' }}>
-              여기는 children 이에요.
-            </div>
-          </>
-        }
-        buttonPosition="column"
-        primaryColor="#F66F00"
-        primaryButton={{
-          text: '확인',
-          onClick: () => {
-            alert('확인');
-          },
-        }}
-        secondaryButton={{ text: '닫기', onClick: handleClose }}
-      />
-    </>
+    <StyledContainer>
+      <UsageModal />
+      <UsageAlertModal />
+      <UsageConfirmModal />
+      <UsagePromptModal />
+    </StyledContainer>
   );
 }
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
 
 export default App;

--- a/components/src/lib/Button/Button.stories.tsx
+++ b/components/src/lib/Button/Button.stories.tsx
@@ -3,7 +3,6 @@ import Button from './Button';
 
 const meta = {
   title: 'Button',
-  tags: ['autodocs'],
   component: Button,
 } satisfies Meta<typeof Button>;
 

--- a/components/src/lib/Button/Button.stories.tsx
+++ b/components/src/lib/Button/Button.stories.tsx
@@ -3,6 +3,7 @@ import Button from './Button';
 
 const meta = {
   title: 'Button',
+  tags: ['autodocs'],
   component: Button,
 } satisfies Meta<typeof Button>;
 

--- a/components/src/lib/Button/Button.stories.tsx
+++ b/components/src/lib/Button/Button.stories.tsx
@@ -21,10 +21,7 @@ export const Default: Story = {
 
 export const Small: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'small',
     buttonStyle: 'primary',
   },
@@ -32,10 +29,7 @@ export const Small: Story = {
 
 export const Large: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'large',
     buttonStyle: 'primary',
   },
@@ -43,10 +37,7 @@ export const Large: Story = {
 
 export const Border: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'medium',
     buttonStyle: 'border',
   },
@@ -54,10 +45,7 @@ export const Border: Story = {
 
 export const Text: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'medium',
     buttonStyle: 'text',
   },
@@ -65,10 +53,7 @@ export const Text: Story = {
 
 export const Fit: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'medium',
     buttonStyle: 'primary',
     width: 'fit',
@@ -77,10 +62,7 @@ export const Fit: Story = {
 
 export const Full: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'medium',
     buttonStyle: 'primary',
     width: 'full',
@@ -89,10 +71,7 @@ export const Full: Story = {
 
 export const Bright: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'medium',
     buttonStyle: 'primary',
     primaryColor: '#FFE600',
@@ -101,10 +80,7 @@ export const Bright: Story = {
 
 export const Dark: Story = {
   args: {
-    text: '버튼입니다',
-    onClick: () => {
-      alert('버튼 클릭');
-    },
+    ...Default.args,
     size: 'medium',
     buttonStyle: 'primary',
     primaryColor: '#f66f00',

--- a/components/src/lib/Button/Button.tsx
+++ b/components/src/lib/Button/Button.tsx
@@ -9,19 +9,16 @@ export interface ButtonProps {
   onClick: () => void;
   /**
    * @defaultValue 'medium'
-   * @remarks type ButtonSize = "small" | "medium" | "large"
    */
   size?: ButtonSize;
 
   /**
    * @defaultValue 'fixed'
-   * @remarks type ButtonWidth = "fixed" | "fit" | "full"
    */
   width?: ButtonWidth;
 
   /**
    * @defaultValue 'primary'
-   * @remarks type ButtonStyle = "primary" | "border" | "text"
    */
   buttonStyle?: ButtonStyle;
 

--- a/components/src/lib/Button/Button.tsx
+++ b/components/src/lib/Button/Button.tsx
@@ -3,12 +3,31 @@ import * as Styled from './Button.styled';
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type ButtonWidth = 'fixed' | 'fit' | 'full';
 export type ButtonStyle = 'primary' | 'border' | 'text';
+
 export interface ButtonProps {
   text: string;
   onClick: () => void;
+  /**
+   * @defaultValue 'medium'
+   * @remarks type ButtonSize = "small" | "medium" | "large"
+   */
   size?: ButtonSize;
+
+  /**
+   * @defaultValue 'fixed'
+   * @remarks type ButtonWidth = "fixed" | "fit" | "full"
+   */
   width?: ButtonWidth;
+
+  /**
+   * @defaultValue 'primary'
+   * @remarks type ButtonStyle = "primary" | "border" | "text"
+   */
   buttonStyle?: ButtonStyle;
+
+  /**
+   * @defaultValue '#333333'
+   */
   primaryColor?: string;
 }
 

--- a/components/src/lib/Input/Input.stories.tsx
+++ b/components/src/lib/Input/Input.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Input from './Input';
+import { fn } from '@storybook/test';
+
+const meta = {
+  title: 'Input',
+  component: Input,
+  argTypes: {
+    value: {
+      control: 'text',
+    },
+  },
+  args: {
+    value: '',
+    onChange: fn(),
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    labelText: 'label',
+    placeholder: 'placeholder',
+  },
+};

--- a/components/src/lib/Input/Input.stories.tsx
+++ b/components/src/lib/Input/Input.stories.tsx
@@ -4,7 +4,6 @@ import { fn } from '@storybook/test';
 
 const meta = {
   title: 'Input',
-  tags: ['autodocs'],
   component: Input,
   argTypes: {
     value: {

--- a/components/src/lib/Input/Input.stories.tsx
+++ b/components/src/lib/Input/Input.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from '@storybook/test';
 
 const meta = {
   title: 'Input',
+  tags: ['autodocs'],
   component: Input,
   argTypes: {
     value: {

--- a/components/src/lib/Input/Input.styled.ts
+++ b/components/src/lib/Input/Input.styled.ts
@@ -1,0 +1,34 @@
+import { LabelPosition } from './Input';
+import styled from 'styled-components';
+
+export const Label = styled.label<{ labelPosition: LabelPosition }>`
+  display: flex;
+  flex-direction: ${(props) => props.labelPosition};
+  align-items: ${(props) => (props.labelPosition === 'row' ? 'center' : '')};
+
+  gap: 8px;
+  color: #333333;
+
+  width: 100%;
+
+  input::placeholder {
+    color: rgba(0, 0, 0, 0.3);
+  }
+`;
+
+export const Input = styled.input<{ primaryColor: string }>`
+  border: 1px solid #333333;
+  outline: none;
+
+  border-radius: 4px;
+  padding: 4px;
+  margin: 4px 0;
+
+  box-sizing: border-box;
+  width: 100%;
+
+  &:hover,
+  &:focus {
+    border: ${(props) => `1px solid ${props.primaryColor}`};
+  }
+`;

--- a/components/src/lib/Input/Input.styled.ts
+++ b/components/src/lib/Input/Input.styled.ts
@@ -6,7 +6,9 @@ export const Label = styled.label<{ labelPosition: LabelPosition }>`
   flex-direction: ${(props) => props.labelPosition};
   align-items: ${(props) => (props.labelPosition === 'row' ? 'center' : '')};
 
-  gap: 8px;
+  gap: ${(props) => (props.labelPosition === 'row' ? '4px' : '')};
+  margin: 4px 0;
+  font-size: 12px;
   color: #333333;
 
   width: 100%;

--- a/components/src/lib/Input/Input.tsx
+++ b/components/src/lib/Input/Input.tsx
@@ -1,0 +1,37 @@
+import * as Styled from './Input.styled';
+
+export interface InputProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+  labelText?: string;
+  labelPosition?: LabelPosition;
+  placeholder?: string;
+
+  primaryColor?: string;
+}
+
+export type LabelPosition = 'row' | 'column';
+
+const Input = ({
+  value,
+  onChange,
+  labelText = '',
+  labelPosition = 'row',
+  placeholder = '',
+  primaryColor,
+}: InputProps) => {
+  return (
+    <Styled.Label labelPosition={labelPosition}>
+      {labelText}
+      <Styled.Input
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        primaryColor={primaryColor || '#333333'}
+      />
+    </Styled.Label>
+  );
+};
+
+export default Input;

--- a/components/src/lib/Input/Input.tsx
+++ b/components/src/lib/Input/Input.tsx
@@ -37,9 +37,10 @@ const Input = ({
   ...props
 }: InputProps) => {
   return labelText ? (
-    <Styled.Label labelPosition={labelPosition}>
+    <Styled.Label labelPosition={labelPosition} htmlFor={props.id}>
       {labelText}
       <Styled.Input
+        id={props.id}
         value={value}
         onChange={onChange}
         placeholder={placeholder}

--- a/components/src/lib/Input/Input.tsx
+++ b/components/src/lib/Input/Input.tsx
@@ -1,6 +1,8 @@
 import * as Styled from './Input.styled';
 
-export interface InputProps {
+import { InputHTMLAttributes } from 'react';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 
@@ -19,7 +21,8 @@ const Input = ({
   labelText = '',
   labelPosition = 'row',
   placeholder = '',
-  primaryColor,
+  primaryColor = '#333333',
+  ...props
 }: InputProps) => {
   return (
     <Styled.Label labelPosition={labelPosition}>
@@ -28,7 +31,8 @@ const Input = ({
         value={value}
         onChange={onChange}
         placeholder={placeholder}
-        primaryColor={primaryColor || '#333333'}
+        primaryColor={primaryColor}
+        {...props}
       />
     </Styled.Label>
   );

--- a/components/src/lib/Input/Input.tsx
+++ b/components/src/lib/Input/Input.tsx
@@ -7,9 +7,21 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 
   labelText?: string;
+
+  /**
+   * @defaultValue 'row'
+   * @remarks type LabelPosition = "row" | "column"
+   */
   labelPosition?: LabelPosition;
+
+  /**
+   * @defaultValue ''
+   */
   placeholder?: string;
 
+  /**
+   * @defaultValue '#333333'
+   */
   primaryColor?: string;
 }
 
@@ -18,13 +30,13 @@ export type LabelPosition = 'row' | 'column';
 const Input = ({
   value,
   onChange,
-  labelText = '',
+  labelText,
   labelPosition = 'row',
   placeholder = '',
   primaryColor = '#333333',
   ...props
 }: InputProps) => {
-  return (
+  return labelText ? (
     <Styled.Label labelPosition={labelPosition}>
       {labelText}
       <Styled.Input
@@ -35,6 +47,14 @@ const Input = ({
         {...props}
       />
     </Styled.Label>
+  ) : (
+    <Styled.Input
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      primaryColor={primaryColor}
+      {...props}
+    />
   );
 };
 

--- a/components/src/lib/Input/Input.tsx
+++ b/components/src/lib/Input/Input.tsx
@@ -10,7 +10,6 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
   /**
    * @defaultValue 'row'
-   * @remarks type LabelPosition = "row" | "column"
    */
   labelPosition?: LabelPosition;
 

--- a/components/src/lib/Modal/AlertModal/AlertModal.stories.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AlertModal from './AlertModal';
+
+const meta = {
+  title: 'AlertModal',
+  component: AlertModal,
+} satisfies Meta<typeof AlertModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpened: true,
+    closeModal: () => {
+      alert('모달 닫기');
+    },
+    title: '제목입니다',
+    content: '본문입니다.',
+  },
+};

--- a/components/src/lib/Modal/AlertModal/AlertModal.stories.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.stories.tsx
@@ -3,6 +3,7 @@ import AlertModal from './AlertModal';
 
 const meta = {
   title: 'AlertModal',
+  tags: ['autodocs'],
   component: AlertModal,
 } satisfies Meta<typeof AlertModal>;
 

--- a/components/src/lib/Modal/AlertModal/AlertModal.stories.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.stories.tsx
@@ -3,7 +3,6 @@ import AlertModal from './AlertModal';
 
 const meta = {
   title: 'AlertModal',
-  tags: ['autodocs'],
   component: AlertModal,
 } satisfies Meta<typeof AlertModal>;
 

--- a/components/src/lib/Modal/AlertModal/AlertModal.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.tsx
@@ -4,12 +4,15 @@ import Modal, {
   ModalSize,
 } from '../Modal';
 
+import { ModalTextBody } from '../Modal.styled';
+
 export interface AlertModalProps {
   isOpened: boolean;
   closeModal: () => void;
   handleConfirm?: () => void;
   title?: string;
   description?: string;
+  content?: string;
   size?: ModalSize;
   children?: JSX.Element;
   modalPosition?: ModalPosition;
@@ -23,6 +26,7 @@ const AlertModal = ({
   handleConfirm = () => {},
   title = '',
   description = '',
+  content = '',
   size = 'large',
   children,
   modalPosition = 'center',
@@ -51,7 +55,10 @@ const AlertModal = ({
         onClick: handleClick,
       }}
     >
-      {children}
+      <>
+        <ModalTextBody>{content}</ModalTextBody>
+        {children}
+      </>
     </Modal>
   );
 };

--- a/components/src/lib/Modal/AlertModal/AlertModal.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.tsx
@@ -13,8 +13,23 @@ export interface AlertModalProps {
   title?: string;
   description?: string;
   content?: string;
+
+  /**
+   * @defaultValue 'large'
+   * @remarks type ModalSize = "small" | "medium" | "large"
+   */
   size?: ModalSize;
+
+  /**
+   * @defaultValue 'center'
+   * @remarks type ModalPosition = "center" | "bottom"
+   */
   modalPosition?: ModalPosition;
+
+  /**
+   * @defaultValue 'right'
+   * @remarks  type ButtonJustifyContent = "center" | "left" | "right"
+   */
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;
 }

--- a/components/src/lib/Modal/AlertModal/AlertModal.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.tsx
@@ -14,7 +14,6 @@ export interface AlertModalProps {
   description?: string;
   content?: string;
   size?: ModalSize;
-  children?: JSX.Element;
   modalPosition?: ModalPosition;
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;
@@ -32,7 +31,7 @@ const AlertModal = ({
   modalPosition = 'center',
   buttonJustifyContent = 'right',
   primaryColor,
-}: AlertModalProps) => {
+}: React.PropsWithChildren<AlertModalProps>) => {
   const handleClick = () => {
     handleConfirm();
     closeModal();
@@ -55,10 +54,8 @@ const AlertModal = ({
         onClick: handleClick,
       }}
     >
-      <>
-        <ModalTextBody>{content}</ModalTextBody>
-        {children}
-      </>
+      <ModalTextBody>{content}</ModalTextBody>
+      {children}
     </Modal>
   );
 };

--- a/components/src/lib/Modal/AlertModal/AlertModal.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.tsx
@@ -16,19 +16,16 @@ export interface AlertModalProps {
 
   /**
    * @defaultValue 'large'
-   * @remarks type ModalSize = "small" | "medium" | "large"
    */
   size?: ModalSize;
 
   /**
    * @defaultValue 'center'
-   * @remarks type ModalPosition = "center" | "bottom"
    */
   modalPosition?: ModalPosition;
 
   /**
    * @defaultValue 'right'
-   * @remarks  type ButtonJustifyContent = "center" | "left" | "right"
    */
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;

--- a/components/src/lib/Modal/AlertModal/AlertModal.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.tsx
@@ -69,7 +69,7 @@ const AlertModal = ({
         onClick: handleClick,
       }}
     >
-      <ModalTextBody>{content}</ModalTextBody>
+      {content && <ModalTextBody>{content}</ModalTextBody>}
       {children}
     </Modal>
   );

--- a/components/src/lib/Modal/AlertModal/AlertModal.tsx
+++ b/components/src/lib/Modal/AlertModal/AlertModal.tsx
@@ -1,0 +1,59 @@
+import Modal, {
+  ButtonJustifyContent,
+  ModalPosition,
+  ModalSize,
+} from '../Modal';
+
+export interface AlertModalProps {
+  isOpened: boolean;
+  closeModal: () => void;
+  handleConfirm?: () => void;
+  title?: string;
+  description?: string;
+  size?: ModalSize;
+  children?: JSX.Element;
+  modalPosition?: ModalPosition;
+  buttonJustifyContent?: ButtonJustifyContent;
+  primaryColor?: string;
+}
+
+const AlertModal = ({
+  isOpened,
+  closeModal,
+  handleConfirm = () => {},
+  title = '',
+  description = '',
+  size = 'large',
+  children,
+  modalPosition = 'center',
+  buttonJustifyContent = 'right',
+  primaryColor,
+}: AlertModalProps) => {
+  const handleClick = () => {
+    handleConfirm();
+    closeModal();
+  };
+
+  return (
+    <Modal
+      isOpened={isOpened}
+      closeModal={closeModal}
+      title={title}
+      description={description}
+      size={size}
+      modalPosition={modalPosition}
+      buttonJustifyContent={buttonJustifyContent}
+      primaryColor={primaryColor}
+      primaryButton={{
+        text: '확인',
+        width: 'fit',
+        size: 'medium',
+        onClick: handleClick,
+      }}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+export default AlertModal;

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.stories.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.stories.tsx
@@ -3,6 +3,7 @@ import ConfirmModal from './ConfirmModal';
 
 const meta = {
   title: 'ConfirmModal',
+  tags: ['autodocs'],
   component: ConfirmModal,
 } satisfies Meta<typeof ConfirmModal>;
 

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.stories.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.stories.tsx
@@ -3,7 +3,6 @@ import ConfirmModal from './ConfirmModal';
 
 const meta = {
   title: 'ConfirmModal',
-  tags: ['autodocs'],
   component: ConfirmModal,
 } satisfies Meta<typeof ConfirmModal>;
 

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.stories.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ConfirmModal from './ConfirmModal';
+
+const meta = {
+  title: 'ConfirmModal',
+  component: ConfirmModal,
+} satisfies Meta<typeof ConfirmModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpened: true,
+    closeModal: () => {
+      alert('모달 닫기');
+    },
+    title: '제목입니다',
+    content: '본문입니다.',
+  },
+};

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
@@ -4,12 +4,15 @@ import Modal, {
   ModalSize,
 } from '../Modal';
 
+import { ModalTextBody } from '../Modal.styled';
+
 export interface ConfirmModalProps {
   isOpened: boolean;
   closeModal: () => void;
   handleConfirm?: () => void;
   title?: string;
   description?: string;
+  content?: string;
   size?: ModalSize;
   children?: JSX.Element;
   modalPosition?: ModalPosition;
@@ -23,6 +26,7 @@ const ConfirmModal = ({
   handleConfirm = () => {},
   title = '',
   description = '',
+  content = '',
   size = 'large',
   children,
   modalPosition = 'center',
@@ -55,7 +59,10 @@ const ConfirmModal = ({
         onClick: closeModal,
       }}
     >
-      {children}
+      <>
+        <ModalTextBody>{content}</ModalTextBody>
+        {children}
+      </>
     </Modal>
   );
 };

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
@@ -16,19 +16,16 @@ export interface ConfirmModalProps {
 
   /**
    * @defaultValue 'large'
-   * @remarks type ModalSize = "small" | "medium" | "large"
    */
   size?: ModalSize;
 
   /**
    * @defaultValue 'center'
-   * @remarks type ModalPosition = "center" | "bottom"
    */
   modalPosition?: ModalPosition;
 
   /**
    * @defaultValue 'right'
-   * @remarks  type ButtonJustifyContent = "center" | "left" | "right"
    */
   buttonJustifyContent?: ButtonJustifyContent;
 

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,63 @@
+import Modal, {
+  ButtonJustifyContent,
+  ModalPosition,
+  ModalSize,
+} from '../Modal';
+
+export interface ConfirmModalProps {
+  isOpened: boolean;
+  closeModal: () => void;
+  handleConfirm?: () => void;
+  title?: string;
+  description?: string;
+  size?: ModalSize;
+  children?: JSX.Element;
+  modalPosition?: ModalPosition;
+  buttonJustifyContent?: ButtonJustifyContent;
+  primaryColor?: string;
+}
+
+const ConfirmModal = ({
+  isOpened,
+  closeModal,
+  handleConfirm = () => {},
+  title = '',
+  description = '',
+  size = 'large',
+  children,
+  modalPosition = 'center',
+  buttonJustifyContent = 'right',
+  primaryColor,
+}: ConfirmModalProps) => {
+  const handleClick = () => {
+    handleConfirm();
+    closeModal();
+  };
+
+  return (
+    <Modal
+      isOpened={isOpened}
+      closeModal={closeModal}
+      title={title}
+      description={description}
+      size={size}
+      modalPosition={modalPosition}
+      buttonJustifyContent={buttonJustifyContent}
+      primaryColor={primaryColor}
+      primaryButton={{
+        text: '확인',
+        width: 'fit',
+        onClick: handleClick,
+      }}
+      secondaryButton={{
+        text: '취소',
+        width: 'fit',
+        onClick: closeModal,
+      }}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
@@ -14,7 +14,6 @@ export interface ConfirmModalProps {
   description?: string;
   content?: string;
   size?: ModalSize;
-  children?: JSX.Element;
   modalPosition?: ModalPosition;
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;
@@ -32,7 +31,7 @@ const ConfirmModal = ({
   modalPosition = 'center',
   buttonJustifyContent = 'right',
   primaryColor,
-}: ConfirmModalProps) => {
+}: React.PropsWithChildren<ConfirmModalProps>) => {
   const handleClick = () => {
     handleConfirm();
     closeModal();
@@ -59,10 +58,8 @@ const ConfirmModal = ({
         onClick: closeModal,
       }}
     >
-      <>
-        <ModalTextBody>{content}</ModalTextBody>
-        {children}
-      </>
+      <ModalTextBody>{content}</ModalTextBody>
+      {children}
     </Modal>
   );
 };

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
@@ -74,7 +74,7 @@ const ConfirmModal = ({
         onClick: closeModal,
       }}
     >
-      <ModalTextBody>{content}</ModalTextBody>
+      {content && <ModalTextBody>{content}</ModalTextBody>}
       {children}
     </Modal>
   );

--- a/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/components/src/lib/Modal/ConfirmModal/ConfirmModal.tsx
@@ -13,9 +13,25 @@ export interface ConfirmModalProps {
   title?: string;
   description?: string;
   content?: string;
+
+  /**
+   * @defaultValue 'large'
+   * @remarks type ModalSize = "small" | "medium" | "large"
+   */
   size?: ModalSize;
+
+  /**
+   * @defaultValue 'center'
+   * @remarks type ModalPosition = "center" | "bottom"
+   */
   modalPosition?: ModalPosition;
+
+  /**
+   * @defaultValue 'right'
+   * @remarks  type ButtonJustifyContent = "center" | "left" | "right"
+   */
   buttonJustifyContent?: ButtonJustifyContent;
+
   primaryColor?: string;
 }
 

--- a/components/src/lib/Modal/CustomModal/CustomModal.ts
+++ b/components/src/lib/Modal/CustomModal/CustomModal.ts
@@ -1,0 +1,16 @@
+import CustomModalBody from './CustomModalBody';
+import CustomModalCloseButton from './CustomModalCloseButton';
+import CustomModalContainer from './CustomModalContainer';
+import CustomModalFooter from './CustomModalFooter';
+import CustomModalHeader from './CustomModalHeader';
+import CustomModalTitle from './CustomModalTitle';
+
+const CustomModal = Object.assign(CustomModalContainer, {
+  Header: CustomModalHeader,
+  Title: CustomModalTitle,
+  CloseButton: CustomModalCloseButton,
+  Body: CustomModalBody,
+  Footer: CustomModalFooter,
+});
+
+export default CustomModal;

--- a/components/src/lib/Modal/CustomModal/CustomModalBody.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalBody.tsx
@@ -1,0 +1,21 @@
+import * as Styled from '../Modal.styled';
+
+import React from 'react';
+
+export interface CustomModalBodyProps {
+  description?: string;
+}
+
+const CustomModalBody = ({
+  description = '',
+  children,
+}: React.PropsWithChildren<CustomModalBodyProps>) => {
+  return (
+    <Styled.ModalBody>
+      <Styled.ModalDescription>{description}</Styled.ModalDescription>
+      {children}
+    </Styled.ModalBody>
+  );
+};
+
+export default CustomModalBody;

--- a/components/src/lib/Modal/CustomModal/CustomModalCloseButton.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalCloseButton.tsx
@@ -1,0 +1,14 @@
+import CLOSE_BUTTON from '../../../asset/close-button.svg';
+import { ModalCloseButton } from '../Modal.styled';
+
+export interface CustomModalCloseButtonProps {
+  closeModal: () => void;
+}
+
+const CustomModalCloseButton = ({
+  closeModal,
+}: CustomModalCloseButtonProps) => {
+  return <ModalCloseButton src={CLOSE_BUTTON} onClick={closeModal} />;
+};
+
+export default CustomModalCloseButton;

--- a/components/src/lib/Modal/CustomModal/CustomModalContainer.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalContainer.tsx
@@ -8,13 +8,11 @@ export interface CustomModalContainerProps {
 
   /**
    * @defaultValue 'center'
-   * @remarks type ModalPosition = "center" | "bottom"
    */
   modalPosition?: ModalPosition;
 
   /**
    * @defaultValue 'large'
-   * @remarks type ModalSize = "small" | "medium" | "large"
    */
   size?: ModalSize;
 }

--- a/components/src/lib/Modal/CustomModal/CustomModalContainer.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalContainer.tsx
@@ -1,0 +1,48 @@
+import * as Styled from '../Modal.styled';
+
+import { ModalPosition, ModalSize } from '../Modal';
+
+export interface CustomModalContainerProps {
+  isOpened: boolean;
+  closeModal: () => void;
+
+  /**
+   * @defaultValue 'center'
+   * @remarks type ModalPosition = "center" | "bottom"
+   */
+  modalPosition?: ModalPosition;
+
+  /**
+   * @defaultValue 'large'
+   * @remarks type ModalSize = "small" | "medium" | "large"
+   */
+  size?: ModalSize;
+}
+
+const CustomModalContainer = ({
+  isOpened,
+  closeModal,
+  modalPosition = 'center',
+  size = 'large',
+  children,
+}: React.PropsWithChildren<CustomModalContainerProps>) => {
+  return (
+    <>
+      {isOpened && (
+        <Styled.DimmedLayer onClick={closeModal}>
+          <Styled.ModalContainer
+            modalPosition={modalPosition}
+            size={size}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            {children}
+          </Styled.ModalContainer>
+        </Styled.DimmedLayer>
+      )}
+    </>
+  );
+};
+
+export default CustomModalContainer;

--- a/components/src/lib/Modal/CustomModal/CustomModalFooter.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalFooter.tsx
@@ -1,0 +1,34 @@
+import { ButtonJustifyContent, ButtonPosition } from '../Modal';
+
+import { ButtonContainer } from '../Modal.styled';
+
+export interface CustomModalFooter {
+  /**
+   * @defaultValue 'row'
+   * @remarks type ButtonPosition = "row" | "column"
+   */
+  buttonPosition?: ButtonPosition;
+
+  /**
+   * @defaultValue 'right'
+   * @remarks type ButtonJustifyContent = "center" | "left" | "right"
+   */
+  buttonJustifyContent?: ButtonJustifyContent;
+}
+
+const CustomModalFooter = ({
+  children,
+  buttonPosition = 'row',
+  buttonJustifyContent = 'right',
+}: React.PropsWithChildren<CustomModalFooter>) => {
+  return (
+    <ButtonContainer
+      buttonPosition={buttonPosition}
+      buttonJustifyContent={buttonJustifyContent}
+    >
+      {children}
+    </ButtonContainer>
+  );
+};
+
+export default CustomModalFooter;

--- a/components/src/lib/Modal/CustomModal/CustomModalFooter.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalFooter.tsx
@@ -5,13 +5,11 @@ import { ButtonContainer } from '../Modal.styled';
 export interface CustomModalFooter {
   /**
    * @defaultValue 'row'
-   * @remarks type ButtonPosition = "row" | "column"
    */
   buttonPosition?: ButtonPosition;
 
   /**
    * @defaultValue 'right'
-   * @remarks type ButtonJustifyContent = "center" | "left" | "right"
    */
   buttonJustifyContent?: ButtonJustifyContent;
 }

--- a/components/src/lib/Modal/CustomModal/CustomModalHeader.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalHeader.tsx
@@ -1,0 +1,7 @@
+import { ModalHeader } from '../Modal.styled';
+
+const CustomModalHeader = ({ children }: React.PropsWithChildren) => {
+  return <ModalHeader>{children}</ModalHeader>;
+};
+
+export default CustomModalHeader;

--- a/components/src/lib/Modal/CustomModal/CustomModalTitle.tsx
+++ b/components/src/lib/Modal/CustomModal/CustomModalTitle.tsx
@@ -1,0 +1,7 @@
+import { ModalTitle } from '../Modal.styled';
+
+const CustomModalTitle = ({ children }: React.PropsWithChildren) => {
+  return <ModalTitle>{children}</ModalTitle>;
+};
+
+export default CustomModalTitle;

--- a/components/src/lib/Modal/Modal.stories.tsx
+++ b/components/src/lib/Modal/Modal.stories.tsx
@@ -3,7 +3,6 @@ import Modal from './Modal';
 
 const meta = {
   title: 'Modal',
-  tags: ['autodocs'],
   component: Modal,
 } satisfies Meta<typeof Modal>;
 

--- a/components/src/lib/Modal/Modal.stories.tsx
+++ b/components/src/lib/Modal/Modal.stories.tsx
@@ -3,6 +3,7 @@ import Modal from './Modal';
 
 const meta = {
   title: 'Modal',
+  tags: ['autodocs'],
   component: Modal,
 } satisfies Meta<typeof Modal>;
 

--- a/components/src/lib/Modal/Modal.styled.ts
+++ b/components/src/lib/Modal/Modal.styled.ts
@@ -1,4 +1,4 @@
-import { ButtonPosition, ModalPosition } from './Modal';
+import { ButtonPosition, ModalPosition, ModalSize } from './Modal';
 
 import styled from 'styled-components';
 
@@ -13,7 +13,16 @@ export const DimmedLayer = styled.div`
   background-color: rgba(0, 0, 0, 0.4);
 `;
 
-export const ModalContainer = styled.div<{ modalPosition: ModalPosition }>`
+const ModalWidth: Record<ModalSize, number> = {
+  small: 320,
+  medium: 480,
+  large: 600,
+};
+
+export const ModalContainer = styled.div<{
+  modalPosition: ModalPosition;
+  size: ModalSize;
+}>`
   position: ${(props) =>
     props.modalPosition === 'center' ? 'relative' : 'fixed'};
   inset: ${(props) =>
@@ -23,7 +32,8 @@ export const ModalContainer = styled.div<{ modalPosition: ModalPosition }>`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: ${(props) => (props.modalPosition === 'center' ? '640px' : '')};
+  max-width: ${(props) =>
+    props.modalPosition === 'center' ? `${ModalWidth[props.size]}px` : ''};
   max-height: 80vh;
   box-sizing: border-box;
   gap: 16px;

--- a/components/src/lib/Modal/Modal.styled.ts
+++ b/components/src/lib/Modal/Modal.styled.ts
@@ -89,6 +89,17 @@ export const ModalDescription = styled.p`
   color: #999999;
 `;
 
+export const ModalTextBody = styled.p`
+  margin-block-start: 0;
+  margin-block-end: 0;
+
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.6;
+  text-align: left;
+  color: #333333;
+`;
+
 export const ButtonContainer = styled.div<{
   buttonPosition: ButtonPosition;
   buttonJustifyContent: ButtonJustifyContent;

--- a/components/src/lib/Modal/Modal.styled.ts
+++ b/components/src/lib/Modal/Modal.styled.ts
@@ -1,4 +1,9 @@
-import { ButtonPosition, ModalPosition, ModalSize } from './Modal';
+import {
+  ButtonJustifyContent,
+  ButtonPosition,
+  ModalPosition,
+  ModalSize,
+} from './Modal';
 
 import styled from 'styled-components';
 
@@ -84,9 +89,14 @@ export const ModalDescription = styled.p`
   color: #999999;
 `;
 
-export const ButtonContainer = styled.div<{ buttonPosition: ButtonPosition }>`
+export const ButtonContainer = styled.div<{
+  buttonPosition: ButtonPosition;
+  buttonJustifyContent: ButtonJustifyContent;
+}>`
   display: flex;
   flex-direction: ${(props) =>
     props.buttonPosition === 'row' ? 'row-reverse' : 'column'};
+
+  justify-content: ${(props) => props.buttonJustifyContent};
   gap: 16px;
 `;

--- a/components/src/lib/Modal/Modal.styled.ts
+++ b/components/src/lib/Modal/Modal.styled.ts
@@ -59,6 +59,8 @@ export const ModalHeader = styled.div`
 export const ModalCloseButton = styled.img`
   width: 18px;
   height: 18px;
+
+  cursor: pointer;
 `;
 
 export const ModalTitle = styled.h2`

--- a/components/src/lib/Modal/Modal.tsx
+++ b/components/src/lib/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import CLOSE_BUTTON from '../../asset/close-button.svg';
 import useBlockedScroll from '../hooks/useBlockedScroll';
 import useEscKeyDown from '../hooks/useEscKeyDown';
 
+export type ModalSize = 'small' | 'medium' | 'large';
 export type ModalPosition = 'center' | 'bottom';
 export type ButtonPosition = 'row' | 'column';
 
@@ -15,6 +16,7 @@ export interface ModalProps {
   closeModal: () => void;
   title?: string;
   description?: string;
+  size?: ModalSize;
   children?: JSX.Element;
   modalPosition?: ModalPosition;
   primaryButton?: ButtonProps;
@@ -38,6 +40,7 @@ const Modal = ({
   closeModal,
   title = '',
   description = '',
+  size = 'large',
   children,
   modalPosition = 'center',
   primaryButton,
@@ -55,6 +58,7 @@ const Modal = ({
         <Styled.DimmedLayer onClick={closeModal}>
           <Styled.ModalContainer
             modalPosition={modalPosition}
+            size={size}
             onClick={(e) => {
               e.stopPropagation();
             }}

--- a/components/src/lib/Modal/Modal.tsx
+++ b/components/src/lib/Modal/Modal.tsx
@@ -17,7 +17,6 @@ export interface ModalProps {
   title?: string;
   description?: string;
   size?: ModalSize;
-  children?: JSX.Element;
   modalPosition?: ModalPosition;
   primaryButton?: ButtonProps;
   secondaryButton?: ButtonProps;
@@ -41,7 +40,7 @@ const Modal = ({
   buttonJustifyContent = 'center',
   primaryColor,
   showCloseButton = false,
-}: ModalProps) => {
+}: React.PropsWithChildren<ModalProps>) => {
   useBlockedScroll(isOpened);
   useEscKeyDown(closeModal);
 

--- a/components/src/lib/Modal/Modal.tsx
+++ b/components/src/lib/Modal/Modal.tsx
@@ -1,15 +1,15 @@
 import * as Styled from './Modal.styled';
 
-import { ButtonSize, ButtonStyle, ButtonWidth } from '../Button/Button';
-
-import Button from '../Button/Button';
-import CLOSE_BUTTON from '../../asset/close-button.svg';
+import { ButtonProps } from '../Button/Button';
+import ModalFooter from './ModalFooter';
+import ModalHeader from './ModalHeader';
 import useBlockedScroll from '../hooks/useBlockedScroll';
 import useEscKeyDown from '../hooks/useEscKeyDown';
 
 export type ModalSize = 'small' | 'medium' | 'large';
 export type ModalPosition = 'center' | 'bottom';
 export type ButtonPosition = 'row' | 'column';
+export type ButtonJustifyContent = 'center' | 'left' | 'right';
 
 export interface ModalProps {
   isOpened: boolean;
@@ -22,17 +22,9 @@ export interface ModalProps {
   primaryButton?: ButtonProps;
   secondaryButton?: ButtonProps;
   buttonPosition?: ButtonPosition;
+  buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;
   showCloseButton?: boolean;
-}
-
-export interface ButtonProps {
-  text: string;
-  onClick: () => void;
-  size?: ButtonSize;
-  width?: ButtonWidth;
-  buttonStyle?: ButtonStyle;
-  primaryColor?: string;
 }
 
 const Modal = ({
@@ -46,11 +38,27 @@ const Modal = ({
   primaryButton,
   secondaryButton,
   buttonPosition = 'row',
+  buttonJustifyContent = 'center',
   primaryColor,
   showCloseButton = false,
 }: ModalProps) => {
   useBlockedScroll(isOpened);
   useEscKeyDown(closeModal);
+
+  const modalHeaderProps = {
+    closeModal,
+    title,
+    showCloseButton,
+  };
+
+  const modalFooterProps = {
+    closeModal,
+    primaryButton,
+    secondaryButton,
+    buttonPosition,
+    buttonJustifyContent,
+    primaryColor,
+  };
 
   return (
     <>
@@ -63,45 +71,12 @@ const Modal = ({
               e.stopPropagation();
             }}
           >
-            <Styled.ModalHeader>
-              <Styled.ModalTitle>{title}</Styled.ModalTitle>
-              {showCloseButton && (
-                <Styled.ModalCloseButton
-                  src={CLOSE_BUTTON}
-                  onClick={closeModal}
-                />
-              )}
-            </Styled.ModalHeader>
+            <ModalHeader {...modalHeaderProps} />
             <Styled.ModalBody>
               <Styled.ModalDescription>{description}</Styled.ModalDescription>
               <div>{children}</div>
             </Styled.ModalBody>
-            <Styled.ButtonContainer buttonPosition={buttonPosition}>
-              {primaryButton && (
-                <Button
-                  text={primaryButton.text}
-                  onClick={primaryButton.onClick}
-                  size={primaryButton.size || 'medium'}
-                  width={primaryButton.width || 'full'}
-                  buttonStyle={primaryButton.buttonStyle || 'primary'}
-                  primaryColor={
-                    primaryColor || primaryButton.primaryColor || '#333333'
-                  }
-                />
-              )}
-              {secondaryButton && (
-                <Button
-                  text={secondaryButton.text}
-                  onClick={secondaryButton.onClick || closeModal}
-                  size={secondaryButton.size || 'medium'}
-                  width={secondaryButton.width || 'full'}
-                  buttonStyle={secondaryButton.buttonStyle || 'border'}
-                  primaryColor={
-                    primaryColor || secondaryButton.primaryColor || '#333333'
-                  }
-                />
-              )}
-            </Styled.ButtonContainer>
+            <ModalFooter {...modalFooterProps} />
           </Styled.ModalContainer>
         </Styled.DimmedLayer>
       )}

--- a/components/src/lib/Modal/Modal.tsx
+++ b/components/src/lib/Modal/Modal.tsx
@@ -19,13 +19,11 @@ export interface ModalProps {
 
   /**
    * @defaultValue 'large'
-   * @remarks type ModalSize = "small" | "medium" | "large"
    */
   size?: ModalSize;
 
   /**
    * @defaultValue 'center'
-   * @remarks type ModalPosition = "center" | "bottom"
    */
   modalPosition?: ModalPosition;
 
@@ -34,13 +32,11 @@ export interface ModalProps {
 
   /**
    * @defaultValue 'row'
-   * @remarks type ButtonPosition = "row" | "column"
    */
   buttonPosition?: ButtonPosition;
 
   /**
    * @defaultValue 'center'
-   * @remarks type ButtonJustifyContent = "center" | "left" | "right"
    */
   buttonJustifyContent?: ButtonJustifyContent;
 

--- a/components/src/lib/Modal/Modal.tsx
+++ b/components/src/lib/Modal/Modal.tsx
@@ -16,13 +16,39 @@ export interface ModalProps {
   closeModal: () => void;
   title?: string;
   description?: string;
+
+  /**
+   * @defaultValue 'large'
+   * @remarks type ModalSize = "small" | "medium" | "large"
+   */
   size?: ModalSize;
+
+  /**
+   * @defaultValue 'center'
+   * @remarks type ModalPosition = "center" | "bottom"
+   */
   modalPosition?: ModalPosition;
+
   primaryButton?: ButtonProps;
   secondaryButton?: ButtonProps;
+
+  /**
+   * @defaultValue 'row'
+   * @remarks type ButtonPosition = "row" | "column"
+   */
   buttonPosition?: ButtonPosition;
+
+  /**
+   * @defaultValue 'center'
+   * @remarks type ButtonJustifyContent = "center" | "left" | "right"
+   */
   buttonJustifyContent?: ButtonJustifyContent;
+
   primaryColor?: string;
+
+  /**
+   * @defaultValue 'false'
+   */
   showCloseButton?: boolean;
 }
 

--- a/components/src/lib/Modal/ModalFooter.tsx
+++ b/components/src/lib/Modal/ModalFooter.tsx
@@ -1,8 +1,9 @@
 import * as Styled from './Modal.styled';
 
-import { ButtonJustifyContent, ButtonPosition, ButtonProps } from './Modal';
+import { ButtonJustifyContent, ButtonPosition } from './Modal';
 
 import { Button } from '..';
+import { ButtonProps } from '../Button/Button';
 
 export interface ModalFooterProps {
   closeModal: () => void;

--- a/components/src/lib/Modal/ModalFooter.tsx
+++ b/components/src/lib/Modal/ModalFooter.tsx
@@ -1,0 +1,56 @@
+import * as Styled from './Modal.styled';
+
+import { ButtonJustifyContent, ButtonPosition, ButtonProps } from './Modal';
+
+import { Button } from '..';
+
+export interface ModalFooterProps {
+  closeModal: () => void;
+
+  primaryColor?: string;
+  primaryButton?: ButtonProps;
+  secondaryButton?: ButtonProps;
+  buttonPosition?: ButtonPosition;
+  buttonJustifyContent?: ButtonJustifyContent;
+}
+
+const ModalFooter = ({
+  closeModal,
+  primaryColor,
+  primaryButton,
+  secondaryButton,
+  buttonPosition = 'row',
+  buttonJustifyContent = 'center',
+}: ModalFooterProps) => {
+  return (
+    <Styled.ButtonContainer
+      buttonPosition={buttonPosition}
+      buttonJustifyContent={buttonJustifyContent}
+    >
+      {primaryButton && (
+        <Button
+          text={primaryButton.text}
+          onClick={primaryButton.onClick}
+          size={primaryButton.size || 'medium'}
+          width={primaryButton.width || 'full'}
+          buttonStyle={primaryButton.buttonStyle || 'primary'}
+          primaryColor={primaryColor || primaryButton.primaryColor || '#333333'}
+        />
+      )}
+      {secondaryButton && (
+        <Button
+          text={secondaryButton.text}
+          onClick={secondaryButton.onClick || closeModal}
+          size={secondaryButton.size || 'medium'}
+          width={secondaryButton.width || 'full'}
+          buttonStyle={secondaryButton.buttonStyle || 'border'}
+          primaryColor={
+            primaryColor || secondaryButton.primaryColor || '#333333'
+          }
+        />
+      )}
+    </Styled.ButtonContainer>
+  );
+};
+
+export default ModalFooter;

--- a/components/src/lib/Modal/ModalHeader.tsx
+++ b/components/src/lib/Modal/ModalHeader.tsx
@@ -1,0 +1,28 @@
+import * as Styled from './Modal.styled';
+
+import CLOSE_BUTTON from '../../asset/close-button.svg';
+
+export interface ModalHeaderProps {
+  closeModal: () => void;
+
+  title?: string;
+  description?: string;
+  showCloseButton?: boolean;
+}
+
+const ModalHeader = ({
+  title,
+  showCloseButton,
+  closeModal,
+}: ModalHeaderProps) => {
+  return (
+    <Styled.ModalHeader>
+      <Styled.ModalTitle>{title}</Styled.ModalTitle>
+      {showCloseButton && (
+        <Styled.ModalCloseButton src={CLOSE_BUTTON} onClick={closeModal} />
+      )}
+    </Styled.ModalHeader>
+  );
+};
+
+export default ModalHeader;

--- a/components/src/lib/Modal/PromptModal/PromptModal.stories.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from '@storybook/test';
 
 const meta = {
   title: 'PromptModal',
+  tags: ['autodocs'],
   component: PromptModal,
   argTypes: {
     value: {

--- a/components/src/lib/Modal/PromptModal/PromptModal.stories.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PromptModal from './PromptModal';
+import { fn } from '@storybook/test';
+
+const meta = {
+  title: 'PromptModal',
+  component: PromptModal,
+  argTypes: {
+    value: {
+      control: 'text',
+    },
+  },
+  args: {
+    value: '',
+    onChange: fn(),
+  },
+} satisfies Meta<typeof PromptModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpened: true,
+    closeModal: () => {
+      alert('모달 닫기');
+    },
+    title: '제목입니다',
+    content: '본문입니다.',
+  },
+};

--- a/components/src/lib/Modal/PromptModal/PromptModal.stories.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.stories.tsx
@@ -4,7 +4,6 @@ import { fn } from '@storybook/test';
 
 const meta = {
   title: 'PromptModal',
-  tags: ['autodocs'],
   component: PromptModal,
   argTypes: {
     value: {

--- a/components/src/lib/Modal/PromptModal/PromptModal.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.tsx
@@ -24,7 +24,6 @@ export interface PromptModalProps {
   description?: string;
   content?: string;
   size?: ModalSize;
-  children?: JSX.Element;
   modalPosition?: ModalPosition;
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;
@@ -50,7 +49,7 @@ const PromptModal = ({
   modalPosition = 'center',
   buttonJustifyContent = 'right',
   primaryColor = '#333333',
-}: PromptModalProps) => {
+}: React.PropsWithChildren<PromptModalProps>) => {
   const handleClick = () => {
     handleConfirm();
     closeModal();
@@ -86,11 +85,9 @@ const PromptModal = ({
         onClick: closeModal,
       }}
     >
-      <>
-        <ModalTextBody>{content}</ModalTextBody>
-        <Input {...inputProps} />
-        {children}
-      </>
+      <ModalTextBody>{content}</ModalTextBody>
+      <Input {...inputProps} />
+      {children}
     </Modal>
   );
 };

--- a/components/src/lib/Modal/PromptModal/PromptModal.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.tsx
@@ -23,8 +23,23 @@ export interface PromptModalProps {
   title?: string;
   description?: string;
   content?: string;
+
+  /**
+   * @defaultValue 'large'
+   * @remarks type ModalSize = "small" | "medium" | "large"
+   */
   size?: ModalSize;
+
+  /**
+   * @defaultValue 'center'
+   * @remarks type ModalPosition = "center" | "bottom"
+   */
   modalPosition?: ModalPosition;
+
+  /**
+   * @defaultValue 'right'
+   * @remarks  type ButtonJustifyContent = "center" | "left" | "right"
+   */
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;
 }

--- a/components/src/lib/Modal/PromptModal/PromptModal.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.tsx
@@ -1,0 +1,98 @@
+import Modal, {
+  ButtonJustifyContent,
+  ModalPosition,
+  ModalSize,
+} from '../Modal';
+
+import { Input } from '../../Input/Input.styled';
+import { LabelPosition } from '../../Input/Input';
+import { ModalTextBody } from '../Modal.styled';
+
+export interface PromptModalProps {
+  isOpened: boolean;
+  closeModal: () => void;
+  handleConfirm?: () => void;
+
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+  labelText?: string;
+  labelPosition?: LabelPosition;
+  placeholder?: string;
+
+  title?: string;
+  description?: string;
+  content?: string;
+  size?: ModalSize;
+  children?: JSX.Element;
+  modalPosition?: ModalPosition;
+  buttonJustifyContent?: ButtonJustifyContent;
+  primaryColor?: string;
+}
+
+const PromptModal = ({
+  isOpened,
+  closeModal,
+  handleConfirm = () => {},
+
+  value,
+  onChange,
+
+  labelText = '',
+  labelPosition = 'row',
+  placeholder = '',
+
+  title = '',
+  description = '',
+  content = '',
+  size = 'large',
+  children,
+  modalPosition = 'center',
+  buttonJustifyContent = 'right',
+  primaryColor = '#333333',
+}: PromptModalProps) => {
+  const handleClick = () => {
+    handleConfirm();
+    closeModal();
+  };
+
+  const inputProps = {
+    value,
+    onChange,
+    labelText,
+    labelPosition,
+    placeholder,
+    primaryColor,
+  };
+
+  return (
+    <Modal
+      isOpened={isOpened}
+      closeModal={closeModal}
+      title={title}
+      description={description}
+      size={size}
+      modalPosition={modalPosition}
+      buttonJustifyContent={buttonJustifyContent}
+      primaryColor={primaryColor}
+      primaryButton={{
+        text: '확인',
+        width: 'fit',
+        onClick: handleClick,
+      }}
+      secondaryButton={{
+        text: '취소',
+        width: 'fit',
+        onClick: closeModal,
+      }}
+    >
+      <>
+        <ModalTextBody>{content}</ModalTextBody>
+        <Input {...inputProps} />
+        {children}
+      </>
+    </Modal>
+  );
+};
+
+export default PromptModal;

--- a/components/src/lib/Modal/PromptModal/PromptModal.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.tsx
@@ -100,7 +100,7 @@ const PromptModal = ({
         onClick: closeModal,
       }}
     >
-      <ModalTextBody>{content}</ModalTextBody>
+      {content && <ModalTextBody>{content}</ModalTextBody>}
       <Input {...inputProps} />
       {children}
     </Modal>

--- a/components/src/lib/Modal/PromptModal/PromptModal.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.tsx
@@ -4,7 +4,7 @@ import Modal, {
   ModalSize,
 } from '../Modal';
 
-import { Input } from '../../Input/Input.styled';
+import Input from '../../Input/Input';
 import { LabelPosition } from '../../Input/Input';
 import { ModalTextBody } from '../Modal.styled';
 

--- a/components/src/lib/Modal/PromptModal/PromptModal.tsx
+++ b/components/src/lib/Modal/PromptModal/PromptModal.tsx
@@ -26,19 +26,16 @@ export interface PromptModalProps {
 
   /**
    * @defaultValue 'large'
-   * @remarks type ModalSize = "small" | "medium" | "large"
    */
   size?: ModalSize;
 
   /**
    * @defaultValue 'center'
-   * @remarks type ModalPosition = "center" | "bottom"
    */
   modalPosition?: ModalPosition;
 
   /**
    * @defaultValue 'right'
-   * @remarks  type ButtonJustifyContent = "center" | "left" | "right"
    */
   buttonJustifyContent?: ButtonJustifyContent;
   primaryColor?: string;

--- a/components/src/lib/hooks/useInput.ts
+++ b/components/src/lib/hooks/useInput.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const useInput = (initValue: string = '') => {
+const useInput = (initValue = '') => {
   const [value, setValue] = useState(initValue);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/src/lib/hooks/useInput.ts
+++ b/components/src/lib/hooks/useInput.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useInput = (initValue: string = '') => {
+  const [value, setValue] = useState(initValue);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  const resetValue = () => {
+    setValue(initValue);
+  };
+
+  return { value, handleChange, resetValue };
+};
+
+export default useInput;

--- a/components/src/lib/hooks/useModal.ts
+++ b/components/src/lib/hooks/useModal.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+const useModal = (initState: boolean = false) => {
+  const [isOpened, setIsOpened] = useState(initState);
+
+  const handelModalClose = () => {
+    setIsOpened(false);
+  };
+
+  const handleModalOpen = () => {
+    setIsOpened(true);
+  };
+
+  const toggleModal = () => {
+    setIsOpened(!isOpened);
+  };
+
+  return { isOpened, handelModalClose, handleModalOpen, toggleModal };
+};
+
+export default useModal;

--- a/components/src/lib/hooks/useModal.ts
+++ b/components/src/lib/hooks/useModal.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const useModal = (initState: boolean = false) => {
+const useModal = (initState = false) => {
   const [isOpened, setIsOpened] = useState(initState);
 
   const handelModalClose = () => {

--- a/components/src/lib/index.ts
+++ b/components/src/lib/index.ts
@@ -1,2 +1,9 @@
 export { default as Modal } from './Modal/Modal';
 export { default as Button } from './Button/Button';
+export { default as Input } from './Input/Input';
+export { default as AlertModal } from './Modal/AlertModal/AlertModal';
+export { default as ConfirmModal } from './Modal/ConfirmModal/ConfirmModal';
+export { default as PromptModal } from './Modal/PromptModal/PromptModal';
+
+export { default as useInput } from './hooks/useInput';
+export { default as useModal } from './hooks/useModal';

--- a/components/src/lib/index.ts
+++ b/components/src/lib/index.ts
@@ -4,6 +4,7 @@ export { default as Input } from './Input/Input';
 export { default as AlertModal } from './Modal/AlertModal/AlertModal';
 export { default as ConfirmModal } from './Modal/ConfirmModal/ConfirmModal';
 export { default as PromptModal } from './Modal/PromptModal/PromptModal';
+export { default as CustomModal } from './Modal/CustomModal/CustomModal';
 
 export { default as useInput } from './hooks/useInput';
 export { default as useModal } from './hooks/useModal';

--- a/components/src/usage/UsageAlertModal.tsx
+++ b/components/src/usage/UsageAlertModal.tsx
@@ -1,0 +1,30 @@
+import AlertModal from '../lib/Modal/AlertModal/AlertModal';
+import { Button } from '../lib';
+import React from 'react';
+import useModal from '../lib/hooks/useModal';
+
+const UsageAlertModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+
+  return (
+    <>
+      <Button
+        text="AlertModal 열기"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <AlertModal
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="AlertModal"
+        content="이것은 알림을 위한 모달입니다. 오로지 확인 버튼만 있습니다."
+        handleConfirm={() => {
+          alert('확인');
+        }}
+      ></AlertModal>
+    </>
+  );
+};
+
+export default UsageAlertModal;

--- a/components/src/usage/UsageConfirmModal.tsx
+++ b/components/src/usage/UsageConfirmModal.tsx
@@ -1,0 +1,30 @@
+import { Button } from '../lib';
+import ConfirmModal from '../lib/Modal/ConfirmModal/ConfirmModal';
+import React from 'react';
+import useModal from '../lib/hooks/useModal';
+
+const UsageConfirmModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+
+  return (
+    <>
+      <Button
+        text="ConfirmModal 열기"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <ConfirmModal
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="ConfirmModal"
+        content="이것은 확인을 위한 모달입니다. 취소 버튼과 확인 버튼이 있습니다."
+        handleConfirm={() => {
+          alert('확인');
+        }}
+      ></ConfirmModal>
+    </>
+  );
+};
+
+export default UsageConfirmModal;

--- a/components/src/usage/UsageCustomModal.tsx
+++ b/components/src/usage/UsageCustomModal.tsx
@@ -1,0 +1,34 @@
+import { Button, CustomModal, useModal } from '../lib';
+
+import CustomModalCloseButton from '../lib/Modal/CustomModal/CustomModalCloseButton';
+import React from 'react';
+
+const UsageCustomModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+
+  return (
+    <>
+      <Button
+        text="CustomModal 열기"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <CustomModal isOpened={isOpened} closeModal={handelModalClose}>
+        <CustomModal.Header>
+          <CustomModal.Title>제목</CustomModal.Title>
+          <CustomModalCloseButton closeModal={handelModalClose} />
+        </CustomModal.Header>
+        <CustomModal.Body>
+          <div>안녕하세요</div>
+          <div>이곳에 원하는 컴포넌트들을 넣어줄 수 있습니다.</div>
+        </CustomModal.Body>
+        <CustomModal.Footer>
+          <Button text="닫기" onClick={handelModalClose} />
+        </CustomModal.Footer>
+      </CustomModal>
+    </>
+  );
+};
+
+export default UsageCustomModal;

--- a/components/src/usage/UsageModal.tsx
+++ b/components/src/usage/UsageModal.tsx
@@ -1,0 +1,47 @@
+import { Button, Modal } from '../lib';
+
+import React from 'react';
+import useModal from '../lib/hooks/useModal';
+
+const UsageModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+
+  return (
+    <>
+      <Button
+        text="Modal 열기"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <Modal
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="안녕하세요, 하루 💙"
+        description="여기는 description 이에요."
+        size="small"
+        children={
+          <>
+            <div style={{ backgroundColor: '#f3e3da', height: '100px' }}>
+              여기는 children 이에요.
+            </div>
+          </>
+        }
+        buttonPosition="column"
+        primaryColor="#F66F00"
+        primaryButton={{
+          text: '확인',
+          onClick: () => {
+            alert('확인');
+          },
+        }}
+        secondaryButton={{
+          text: '닫기',
+          onClick: handelModalClose,
+        }}
+      />
+    </>
+  );
+};
+
+export default UsageModal;

--- a/components/src/usage/UsageModal.tsx
+++ b/components/src/usage/UsageModal.tsx
@@ -21,11 +21,9 @@ const UsageModal = () => {
         description="여기는 description 이에요."
         size="small"
         children={
-          <>
-            <div style={{ backgroundColor: '#f3e3da', height: '100px' }}>
-              여기는 children 이에요.
-            </div>
-          </>
+          <div style={{ backgroundColor: '#f3e3da', height: '100px' }}>
+            여기는 children 이에요.
+          </div>
         }
         buttonPosition="column"
         primaryColor="#F66F00"

--- a/components/src/usage/UsagePromptModal.tsx
+++ b/components/src/usage/UsagePromptModal.tsx
@@ -1,0 +1,35 @@
+import { Button } from '../lib';
+import PromptModal from '../lib/Modal/PromptModal/PromptModal';
+import React from 'react';
+import useInput from '../lib/hooks/useInput';
+import useModal from '../lib/hooks/useModal';
+
+const UsagePromptModal = () => {
+  const { isOpened, handleModalOpen, handelModalClose } = useModal();
+  const { value, handleChange, resetValue } = useInput();
+
+  return (
+    <>
+      <Button
+        text="PromptModal 열기"
+        size="large"
+        width="fit"
+        onClick={handleModalOpen}
+      />
+      <PromptModal
+        value={value}
+        onChange={handleChange}
+        isOpened={isOpened}
+        closeModal={handelModalClose}
+        title="PromptModal"
+        content="이것은 입력을 위한 모달입니다. input에 대한 value 설정이 필요합니다."
+        handleConfirm={() => {
+          alert(`확인\nvalue: ${value}`);
+          resetValue();
+        }}
+      ></PromptModal>
+    </>
+  );
+};
+
+export default UsagePromptModal;

--- a/components/tsconfig.json
+++ b/components/tsconfig.json
@@ -5,6 +5,8 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/hooks/.prettierrc
+++ b/hooks/.prettierrc
@@ -1,12 +1,12 @@
 {
-	"singleQuote": true,
-	"semi": true,
-	"useTabs": false,
-	"tabWidth": 2,
-	"trailingComma": "all",
-	"printWidth": 80,
-	"bracketSpacing": true,
-	"arrowParens": "always",
-	"endOfLine": "auto",
-	"prefer-const": true
+  "singleQuote": true,
+  "semi": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "auto",
+  "prefer-const": true
 }

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -14,6 +14,52 @@ npm install hain-tain-hooks
 
 ### Quick start
 
+> 🤔 **What is the difference between useCardNumber and useCardNumbers?**
+>
+> For useCardNumber, the card number is managed as a **`string`** value, and for useCardNumbers, the card number is managed as a **`string[]`** value.
+>
+> Therefore, useCardNumber can be used with one **`input`**, and useCardNumbers can be used with multiple **`inputs`**.
+
+- **useCardNumber**
+
+```js
+import useCardNumber from 'hain-tain-hooks';
+
+const CardNumber = () => {
+  const {
+    value,
+    formattingValue,
+    errorMessage,
+    cardBrand,
+    onChangeHandler,
+    onBlurHandler,
+    onFocusHandler,
+  } = useCardNumber('');
+
+  return (
+    <>
+      <p>{cardBrand}</p>
+      <input
+        value={formattingValue}
+        onChange={onChangeHandler}
+        onBlur={onBlurHandler}
+        onFocus={onFocusHandler}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' || e.key === 'Enter') {
+            e.currentTarget.blur();
+          }
+        }}
+      />
+      <p>value: {value}</p>
+      <p>formattingValue : {formattingValue}</p>
+      <p style={{ color: 'red' }}>{errorMessage}</p>
+    </>
+  );
+};
+
+export default CardNumber;
+```
+
 - **useCardNumbers**
 
 ```js
@@ -232,6 +278,7 @@ export default CardPassword;
 
 - `useValidateInput`
 - `useValidateInputs`
+- `useCardNumber`
 - `useCardNumbers`
 - `useCardCompany`
 - `useCardExpiration`

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -231,7 +231,7 @@ export default CardPassword;
 #### Top-Level Exports
 
 - `useValidateInput`
-- `useValidateArrayInput`
+- `useValidateInputs`
 - `useCardNumbers`
 - `useCardCompany`
 - `useCardExpiration`

--- a/hooks/package-lock.json
+++ b/hooks/package-lock.json
@@ -4646,27 +4646,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/hain-tain-hooks": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/hain-tain-hooks/-/hain-tain-hooks-0.0.2.tgz",
-      "integrity": "sha512-c2a6xvV9yE0zn/Z2MEWoYCd5XP68wjIUX9AlHIbsPD9lgXgupTJsZiTY9k0XkMh/4kK5aRoycDzjmGv0wWmJLg==",
-      "dependencies": {
-        "hain-tain-hooks": "^0.0.1",
-        "prettier": "^3.2.5",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/hain-tain-hooks/node_modules/hain-tain-hooks": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/hain-tain-hooks/-/hain-tain-hooks-0.0.1.tgz",
-      "integrity": "sha512-RF7o6fyReRUn4/aKGNKC0VBbz0q/mBGYIo2ozafODWbSvHXlnSkNOjatmotL02bEbbtIkkEvH+gmm3JwcV/3gA==",
-      "dependencies": {
-        "prettier": "^3.2.5",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6868,6 +6847,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/hooks/package-lock.json
+++ b/hooks/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hain-tain-hooks",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hain-tain-hooks",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hain-tain-hooks",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "This is a module created for practice",
   "type": "module",
   "types": "dist/index.d.ts",

--- a/hooks/src/App.tsx
+++ b/hooks/src/App.tsx
@@ -4,6 +4,7 @@ import CardCVC from './components/CardCVC';
 import CardCompany from './components/CardCompany';
 import CardExpirationDate from './components/CardExpirationDate';
 import CardHolderName from './components/CardHolderName';
+import CardNumber from './components/CardNumber';
 import CardNumbers from './components/CardNumbers';
 import CardPassword from './components/CardPassword';
 import React from 'react';
@@ -11,6 +12,8 @@ import React from 'react';
 function App() {
   return (
     <div>
+      <h2>CardNumber</h2>
+      <CardNumber />
       <h2>CardNumbers</h2>
       <CardNumbers />
       <h2>CardCompany</h2>

--- a/hooks/src/components/CardNumber.tsx
+++ b/hooks/src/components/CardNumber.tsx
@@ -1,0 +1,35 @@
+import useCardNumber from '../lib/useCardNumber/useCardNumber';
+
+const CardNumber = () => {
+  const {
+    value,
+    formattingValue,
+    errorMessage,
+    cardBrand,
+    onChangeHandler,
+    onBlurHandler,
+    onFocusHandler,
+  } = useCardNumber('');
+
+  return (
+    <>
+      <p>{cardBrand}</p>
+      <input
+        value={formattingValue}
+        onChange={onChangeHandler}
+        onBlur={onBlurHandler}
+        onFocus={onFocusHandler}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' || e.key === 'Enter') {
+            e.currentTarget.blur();
+          }
+        }}
+      />
+      <p>value: {value}</p>
+      <p>formattingValue : {formattingValue}</p>
+      <p style={{ color: 'red' }}>{errorMessage}</p>
+    </>
+  );
+};
+
+export default CardNumber;

--- a/hooks/src/lib/constants/cardBrand.ts
+++ b/hooks/src/lib/constants/cardBrand.ts
@@ -1,10 +1,4 @@
-export type CARD_BRAND_TYPE =
-  | 'VISA'
-  | 'MASTERCARD'
-  | 'AMEX'
-  | 'DINERS'
-  | 'UNIONPAY'
-  | 'NONE';
+export type CardBrandType = keyof typeof CARD_BRAND;
 
 export const CARD_BRAND = {
   VISA: {

--- a/hooks/src/lib/constants/cardBrand.ts
+++ b/hooks/src/lib/constants/cardBrand.ts
@@ -35,7 +35,8 @@ export const CARD_BRAND = {
     name: 'UnionPay',
     formattingRules: [4, 4, 4, 4],
     requiredLength: 16,
-    condition: /^(6221[2-9][6-9]|622[2-8]\d\d?|624|625|626|628[2-8])\d*$/,
+    condition:
+      /^(622(1[2-9][6-9]|[2-8]\d\d|9[01]\d|925\d|927[0-8]\d)|628[2-8]|624|625|626)\d*$/,
   },
   NONE: {
     name: 'none',

--- a/hooks/src/lib/constants/cardBrand.ts
+++ b/hooks/src/lib/constants/cardBrand.ts
@@ -1,0 +1,46 @@
+export type CARD_BRAND_TYPE =
+  | 'VISA'
+  | 'MASTERCARD'
+  | 'AMEX'
+  | 'DINERS'
+  | 'UNIONPAY'
+  | 'NONE';
+
+export const CARD_BRAND = {
+  VISA: {
+    name: 'Visa',
+    formattingRules: [4, 4, 4, 4],
+    requiredLength: 16,
+    condition: /^4\d*$/,
+  },
+  MASTERCARD: {
+    name: 'Mastercard',
+    formattingRules: [4, 4, 4, 4],
+    requiredLength: 16,
+    condition: /^(5[1-5])\d*$/,
+  },
+  AMEX: {
+    name: 'AMEX',
+    formattingRules: [4, 6, 5],
+    requiredLength: 15,
+    condition: /^(34|37)\d*$/,
+  },
+  DINERS: {
+    name: 'Diners',
+    formattingRules: [4, 6, 4],
+    requiredLength: 14,
+    condition: /^36\d*$/,
+  },
+  UNIONPAY: {
+    name: 'UnionPay',
+    formattingRules: [4, 4, 4, 4],
+    requiredLength: 16,
+    condition: /^(6221[2-9][6-9]|622[2-8]\d\d?|624|625|626|628[2-8])\d*$/,
+  },
+  NONE: {
+    name: 'none',
+    formattingRules: [4, 4, 4, 4],
+    requiredLength: 16,
+    condition: /^[0-9]+$/,
+  },
+} as const;

--- a/hooks/src/lib/index.ts
+++ b/hooks/src/lib/index.ts
@@ -4,5 +4,6 @@ export { default as useCardCompany } from './useCardCompany/useCardCompany';
 export { default as useCardCVC } from './useCardCVC/useCardCVC';
 export { default as useCardExpirationDate } from './useCardExpirationDate/useCardExpirationDate';
 export { default as useCardHolderName } from './useCardHolderName/useCardHolderName';
+export { default as useCardNumber } from './useCardNumber/useCardNumber';
 export { default as useCardNumbers } from './useCardNumbers/useCardNumbers';
 export { default as useCardPassword } from './useCardPassword/useCardPassword';

--- a/hooks/src/lib/index.ts
+++ b/hooks/src/lib/index.ts
@@ -1,5 +1,5 @@
 export { default as useValidateInput } from './useValidateInput/useValidateInput';
-export { default as useValidateArrayInput } from './useValidateArrayInput/useValidateArrayInput';
+export { default as useValidateInputs } from './useValidateInputs/useValidateInputs';
 export { default as useCardCompany } from './useCardCompany/useCardCompany';
 export { default as useCardCVC } from './useCardCVC/useCardCVC';
 export { default as useCardExpirationDate } from './useCardExpirationDate/useCardExpirationDate';

--- a/hooks/src/lib/useCardCVC/useCardCVC.test.ts
+++ b/hooks/src/lib/useCardCVC/useCardCVC.test.ts
@@ -2,7 +2,7 @@ import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import useCardCVC from './useCardCVC';
 
-describe('useCardCVC custom hook', () => {
+describe('useCardCVC', () => {
   const maxLength = 3;
 
   test('hook이 초기화되면, 주어진 initValue로 설정된다.', () => {

--- a/hooks/src/lib/useCardCompany/useCardCompany.test.ts
+++ b/hooks/src/lib/useCardCompany/useCardCompany.test.ts
@@ -2,7 +2,7 @@ import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import useCardCompany from './useCardCompany';
 
-describe('useCardCompany custom hook', () => {
+describe('useCardCompany', () => {
   const companyList = ['카카오뱅크', '현대카드', '신한카드', '국민카드'];
 
   test('존재하는 카드사를 입력 후 포커스가 해제되면 isCompleted 상태가 true가 된다.', () => {

--- a/hooks/src/lib/useCardExpirationDate/useCardExpirationDate.test.ts
+++ b/hooks/src/lib/useCardExpirationDate/useCardExpirationDate.test.ts
@@ -3,7 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import useCardExpirationDate from './useCardExpirationDate';
 
-describe('useCardExpirationDate custom hook', () => {
+describe('useCardExpirationDate', () => {
   test('hook이 초기화될 때 주어진 initValue로 설정된다.', () => {
     const { result } = renderHook(() => useCardExpirationDate(['12', '23'], 2));
     expect(result.current.values).toEqual(['12', '23']);

--- a/hooks/src/lib/useCardExpirationDate/useCardExpirationDate.ts
+++ b/hooks/src/lib/useCardExpirationDate/useCardExpirationDate.ts
@@ -1,6 +1,6 @@
 import { isOnlyNumber, isValidMonth } from '../utils/validateCardInfo';
 
-import useValidateArrayInput from '../useValidateArrayInput/useValidateArrayInput';
+import useValidateInputs from '../useValidateInputs/useValidateInputs';
 
 const useCardExpirationDate = (initValue: string[], maxLength: number = 2) => {
   const validateOnChange = (newValue: string, index: number) => {
@@ -57,7 +57,7 @@ const useCardExpirationDate = (initValue: string[], maxLength: number = 2) => {
     onChangeHandler,
     onFocusHandler,
     onBlurHandler,
-  } = useValidateArrayInput({
+  } = useValidateInputs({
     initValue,
     validateOnChange,
     validateOnBlurAll,

--- a/hooks/src/lib/useCardHolderName/useCardHolderName.test.ts
+++ b/hooks/src/lib/useCardHolderName/useCardHolderName.test.ts
@@ -2,7 +2,7 @@ import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import useCardHolderName from './useCardHolderName';
 
-describe('useCardHolderName custom hook', () => {
+describe('useCardHolderName', () => {
   const maxLength = 50;
 
   test('hook이 초기화될 때 주어진 initValue로 설정된다.', () => {

--- a/hooks/src/lib/useCardNumber/useCardNumber.test.ts
+++ b/hooks/src/lib/useCardNumber/useCardNumber.test.ts
@@ -1,0 +1,160 @@
+import { CARD_BRAND } from '../constants/cardBrand';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
+import useCardNumber from './useCardNumber';
+
+describe('useCardNumber', () => {
+  describe('초기값 설정', () => {
+    test('hook이 초기화될 때 주어진 initValue로 설정된다.', () => {
+      const { result } = renderHook(() => useCardNumber('1234'));
+
+      expect(result.current.value).toEqual('1234');
+    });
+  });
+
+  describe('카드번호 업데이트', () => {
+    test(`카드번호가 업데이트되면 value와 formattingValue가 업데이트된다.`, () => {
+      const { result } = renderHook(() => useCardNumber(''));
+
+      act(() => {
+        result.current.onChangeHandler({
+          target: { value: '12345678' },
+        } as any);
+      });
+
+      expect(result.current.value).toBe(`12345678`);
+      expect(result.current.formattingValue).toBe(`1234-5678`);
+    });
+  });
+
+  describe('카드번호 유효성 검사', () => {
+    const maxLength = 16;
+
+    test(`카드 번호에 숫자가 아닌 문자를 입력하면 "카드번호는 숫자만 입력이 가능해요." 라는 errorMessage를 반환한다.`, () => {
+      const { result } = renderHook(() => useCardNumber(''));
+
+      act(() => {
+        result.current.onChangeHandler({
+          target: { value: 'abcd' },
+        } as any);
+      });
+
+      expect(result.current.errorMessage).toBe(
+        `카드번호는 숫자만 입력이 가능해요.`,
+      );
+    });
+
+    test(`카드번호에서 ${maxLength}를 초과하는 값을 입력하면 "카드번호는 ${maxLength}글자 까지만 입력이 가능해요." 라는 errorMessage를 반환한다.`, () => {
+      const { result } = renderHook(() => useCardNumber(''));
+
+      act(() => {
+        result.current.onChangeHandler({
+          target: { value: '12345678123456789' },
+        } as any);
+      });
+
+      expect(result.current.errorMessage).toBe(
+        `카드번호는 ${maxLength}글자 까지만 입력이 가능해요.`,
+      );
+    });
+  });
+
+  describe('카드 브랜드 식별', () => {
+    test.each([
+      // Visa
+      ['4111111111111111', CARD_BRAND.VISA.name],
+      ['4012888888881881', CARD_BRAND.VISA.name],
+      ['3111111111111111', CARD_BRAND.NONE.name],
+
+      // Mastercard
+      ['5011111111111111', CARD_BRAND.NONE.name],
+      ['5111111111111111', CARD_BRAND.MASTERCARD.name],
+      ['5211111111111111', CARD_BRAND.MASTERCARD.name],
+      ['5311111111111111', CARD_BRAND.MASTERCARD.name],
+      ['5411111111111111', CARD_BRAND.MASTERCARD.name],
+      ['5511111111111111', CARD_BRAND.MASTERCARD.name],
+      ['5611111111111111', CARD_BRAND.NONE.name],
+      ['6111111111111111', CARD_BRAND.NONE.name],
+
+      // AMEX
+      ['331111111111111', CARD_BRAND.NONE.name],
+      ['341111111111111', CARD_BRAND.AMEX.name],
+      ['371111111111111', CARD_BRAND.AMEX.name],
+      ['381111111111111', CARD_BRAND.NONE.name],
+
+      // Diners
+      ['36111111111111', CARD_BRAND.DINERS.name],
+      ['35111111111111', CARD_BRAND.NONE.name],
+
+      // UnionPay
+      ['6231111111111111', CARD_BRAND.NONE.name],
+      ['6241111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6251111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6261111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6271111111111111', CARD_BRAND.NONE.name],
+
+      ['6281111111111111', CARD_BRAND.NONE.name],
+      ['6282111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6283111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6284111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6285111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6286111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6287111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6288111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6289111111111111', CARD_BRAND.NONE.name],
+
+      ['6221251111111111', CARD_BRAND.NONE.name],
+      ['6221261111111111', CARD_BRAND.UNIONPAY.name],
+      ['6222111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6223111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6224111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6225111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6226111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6227111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6228111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6229111111111111', CARD_BRAND.UNIONPAY.name],
+      ['6229251111111111', CARD_BRAND.UNIONPAY.name],
+      ['6229261111111111', CARD_BRAND.NONE.name],
+    ])(
+      '카드 번호에 따라 카드 브랜드를 반환한다. (%s)',
+      (cardNumber, cardBrand) => {
+        const { result } = renderHook(() => useCardNumber(''));
+
+        act(() => {
+          result.current.onChangeHandler({
+            target: { value: cardNumber },
+          } as any);
+        });
+
+        expect(result.current.cardBrand).toBe(cardBrand);
+      },
+    );
+  });
+
+  describe('카드 브랜드 포멧팅 결과 확인', () => {
+    test.each([
+      // Visa
+      ['4111111111111111', '4111-1111-1111-1111'],
+      // Mastercard
+      ['5111111111111111', '5111-1111-1111-1111'],
+      // AMEX
+      ['341111111111111', '3411-111111-11111'],
+      // Diners
+      ['36111111111111', '3611-111111-1111'],
+      // UnionPay
+      ['6241111111111111', '6241-1111-1111-1111'],
+      //None
+      ['1234567812345678', '1234-5678-1234-5678'],
+    ])('카드 브랜드에 따라 포멧팅', (cardNumber, formattedCardNumber) => {
+      const { result } = renderHook(() => useCardNumber(''));
+
+      act(() => {
+        result.current.onChangeHandler({
+          target: { value: cardNumber },
+        } as any);
+      });
+
+      expect(result.current.formattingValue).toBe(formattedCardNumber);
+    });
+  });
+});

--- a/hooks/src/lib/useCardNumber/useCardNumber.ts
+++ b/hooks/src/lib/useCardNumber/useCardNumber.ts
@@ -25,7 +25,7 @@ const useCardNumber = (initValue: string, formattingChar: string = '-') => {
     return { isValid: true, errorMessage: '' };
   };
 
-  const decorator = (newValue: string) => {
+  const formatter = (newValue: string) => {
     return newValue.split(formattingChar).join('');
   };
 
@@ -53,7 +53,7 @@ const useCardNumber = (initValue: string, formattingChar: string = '-') => {
     initValue,
     validateOnChange,
     validateOnBlur,
-    decorator,
+    formatter,
   });
 
   const formattingValue = splitByLengthList(

--- a/hooks/src/lib/useCardNumber/useCardNumber.ts
+++ b/hooks/src/lib/useCardNumber/useCardNumber.ts
@@ -1,0 +1,72 @@
+import { isOnlyNumber } from '../utils/validateCardInfo';
+import { judgeCardBrand } from '../utils/judgeCardBrand';
+import splitByLengthList from '../utils/splitByLengthList';
+import useValidateInput from '../useValidateInput/useValidateInput';
+
+const useCardNumber = (initValue: string, formattingChar: string = '-') => {
+  const validateOnChange = (newValue: string) => {
+    const cardBrand = judgeCardBrand(value);
+    const maxLength = cardBrand.requiredLength;
+
+    const temp = newValue.split(formattingChar).join('');
+
+    if (temp.length > maxLength) {
+      return {
+        isValid: false,
+        errorMessage: `카드번호는 ${maxLength}글자 까지만 입력이 가능해요.`,
+      };
+    }
+    if (isOnlyNumber(temp)) {
+      return {
+        isValid: false,
+        errorMessage: '카드번호는 숫자만 입력이 가능해요.',
+      };
+    }
+    return { isValid: true, errorMessage: '' };
+  };
+
+  const decorator = (newValue: string) => {
+    return newValue.split(formattingChar).join('');
+  };
+
+  const validateOnBlur = () => {
+    const cardBrand = judgeCardBrand(value);
+    const maxLength = cardBrand.requiredLength;
+
+    if (value.length !== maxLength) {
+      return {
+        isValid: false,
+        errorMessage: `카드번호는 ${maxLength}글자로 입력해 주세요.`,
+      };
+    }
+    return { isValid: true, errorMessage: '' };
+  };
+
+  const {
+    value,
+    errorMessage,
+    isCompleted,
+    onChangeHandler,
+    onFocusHandler,
+    onBlurHandler,
+  } = useValidateInput({
+    initValue,
+    validateOnChange,
+    validateOnBlur,
+    decorator,
+  });
+
+  return {
+    value,
+    cardBrand: judgeCardBrand(value).name,
+    formattingValue: splitByLengthList(value.split(formattingChar).join(''), [
+      ...judgeCardBrand(value).formattingRules,
+    ]).join(formattingChar),
+    errorMessage,
+    isCompleted,
+    onChangeHandler,
+    onBlurHandler,
+    onFocusHandler,
+  };
+};
+export default useCardNumber;

--- a/hooks/src/lib/useCardNumber/useCardNumber.ts
+++ b/hooks/src/lib/useCardNumber/useCardNumber.ts
@@ -56,12 +56,15 @@ const useCardNumber = (initValue: string, formattingChar: string = '-') => {
     decorator,
   });
 
+  const formattingValue = splitByLengthList(
+    value.split(formattingChar).join(''),
+    [...judgeCardBrand(value).formattingRules],
+  ).join(formattingChar);
+
   return {
     value,
     cardBrand: judgeCardBrand(value).name,
-    formattingValue: splitByLengthList(value.split(formattingChar).join(''), [
-      ...judgeCardBrand(value).formattingRules,
-    ]).join(formattingChar),
+    formattingValue,
     errorMessage,
     isCompleted,
     onChangeHandler,

--- a/hooks/src/lib/useCardNumbers/useCardNumbers.test.ts
+++ b/hooks/src/lib/useCardNumbers/useCardNumbers.test.ts
@@ -2,7 +2,7 @@ import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import useCardNumbers from './useCardNumbers';
 
-describe('useCardNumbers custom hook', () => {
+describe('useCardNumbers', () => {
   const maxLength = 4;
 
   test('hook이 초기화될 때 주어진 initValue로 설정된다.', () => {

--- a/hooks/src/lib/useCardNumbers/useCardNumbers.ts
+++ b/hooks/src/lib/useCardNumbers/useCardNumbers.ts
@@ -1,5 +1,5 @@
 import { isOnlyNumber } from '../utils/validateCardInfo';
-import useValidateArrayInput from '../useValidateArrayInput/useValidateArrayInput';
+import useValidateInputs from '../useValidateInputs/useValidateInputs';
 
 const useCardNumbers = (initValue: string[], maxLength: number = 4) => {
   const validateOnChange = (newValue: string) => {
@@ -38,7 +38,7 @@ const useCardNumbers = (initValue: string[], maxLength: number = 4) => {
     onChangeHandler,
     onFocusHandler,
     onBlurHandler,
-  } = useValidateArrayInput({
+  } = useValidateInputs({
     initValue,
     validateOnChange,
     validateOnBlurAll,

--- a/hooks/src/lib/useCardPassword/useCardPassword.test.ts
+++ b/hooks/src/lib/useCardPassword/useCardPassword.test.ts
@@ -2,7 +2,7 @@ import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import useCardPassword from './useCardPassword';
 
-describe('useCardPassword custom hook', () => {
+describe('useCardPassword', () => {
   const maxLength = 2;
 
   test('hook이 초기화되면, 주어진 initValue로 설정된다.', () => {

--- a/hooks/src/lib/useValidateInput/useValidateInput.test.ts
+++ b/hooks/src/lib/useValidateInput/useValidateInput.test.ts
@@ -3,7 +3,7 @@ import useValidateInput, { ValidateResult } from './useValidateInput';
 import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 
-describe('useValidateInput custom hook 테스트', () => {
+describe('useValidateInput', () => {
   let validateOnChangeMock: jest.Mock<ValidateResult, [string]>;
   let validateOnBlurMock: jest.Mock<ValidateResult, []>;
 

--- a/hooks/src/lib/useValidateInput/useValidateInput.ts
+++ b/hooks/src/lib/useValidateInput/useValidateInput.ts
@@ -4,7 +4,7 @@ export interface UseCardValidateProps {
   initValue: string;
   validateOnChange: (value: string) => ValidateResult;
   validateOnBlur: () => ValidateResult;
-  decorator?: (value: string) => string;
+  formatter?: (value: string) => string;
 }
 
 export interface ValidateResult {
@@ -16,7 +16,7 @@ const useValidateInput = ({
   initValue,
   validateOnChange,
   validateOnBlur,
-  decorator = (value: string) => value,
+  formatter = (value: string) => value,
 }: UseCardValidateProps) => {
   const [value, setValue] = useState(initValue);
   const [isCompleted, setIsCompleted] = useState(false);
@@ -34,7 +34,7 @@ const useValidateInput = ({
       return;
     }
     setErrorMessage('');
-    setValue(decorator(newValue));
+    setValue(formatter(newValue));
   };
 
   const onFocusHandler = () => {

--- a/hooks/src/lib/useValidateInput/useValidateInput.ts
+++ b/hooks/src/lib/useValidateInput/useValidateInput.ts
@@ -4,6 +4,7 @@ export interface UseCardValidateProps {
   initValue: string;
   validateOnChange: (value: string) => ValidateResult;
   validateOnBlur: () => ValidateResult;
+  decorator?: (value: string) => string;
 }
 
 export interface ValidateResult {
@@ -15,6 +16,7 @@ const useValidateInput = ({
   initValue,
   validateOnChange,
   validateOnBlur,
+  decorator = (value: string) => value,
 }: UseCardValidateProps) => {
   const [value, setValue] = useState(initValue);
   const [isCompleted, setIsCompleted] = useState(false);
@@ -32,7 +34,7 @@ const useValidateInput = ({
       return;
     }
     setErrorMessage('');
-    setValue(newValue);
+    setValue(decorator(newValue));
   };
 
   const onFocusHandler = () => {

--- a/hooks/src/lib/useValidateInputs/useValidateInputs.test.ts
+++ b/hooks/src/lib/useValidateInputs/useValidateInputs.test.ts
@@ -3,7 +3,7 @@ import useValidateInputs, { ValidateResult } from './useValidateInputs';
 
 import { act } from 'react';
 
-describe('useValidateInputs custom hook', () => {
+describe('useValidateInputs', () => {
   let validateOnChangeMock: jest.Mock<ValidateResult, [string, number]>;
   let validateOnBlurMock: jest.Mock<ValidateResult>;
 

--- a/hooks/src/lib/useValidateInputs/useValidateInputs.test.ts
+++ b/hooks/src/lib/useValidateInputs/useValidateInputs.test.ts
@@ -1,9 +1,9 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import useValidateArrayInput, { ValidateResult } from './useValidateArrayInput';
+import useValidateInputs, { ValidateResult } from './useValidateInputs';
 
 import { act } from 'react';
 
-describe('useValidateArrayInput custom hook', () => {
+describe('useValidateInputs custom hook', () => {
   let validateOnChangeMock: jest.Mock<ValidateResult, [string, number]>;
   let validateOnBlurMock: jest.Mock<ValidateResult>;
 
@@ -16,7 +16,7 @@ describe('useValidateArrayInput custom hook', () => {
     validateOnBlurMock.mockReturnValue({ isValid: false, errorMessage: '' });
 
     const { result } = renderHook(() =>
-      useValidateArrayInput({
+      useValidateInputs({
         initValue: ['12', ''],
         validateOnChange: validateOnChangeMock,
         validateOnBlurAll: validateOnBlurMock,
@@ -32,7 +32,7 @@ describe('useValidateArrayInput custom hook', () => {
     validateOnChangeMock.mockReturnValue({ isValid: true, errorMessage: '' });
 
     const { result } = renderHook(() =>
-      useValidateArrayInput({
+      useValidateInputs({
         initValue: ['', ''],
         validateOnChange: validateOnChangeMock,
         validateOnBlurAll: validateOnBlurMock,
@@ -55,7 +55,7 @@ describe('useValidateArrayInput custom hook', () => {
     });
 
     const { result } = renderHook(() =>
-      useValidateArrayInput({
+      useValidateInputs({
         initValue: ['', ''],
         validateOnChange: validateOnChangeMock,
         validateOnBlurAll: validateOnBlurMock,
@@ -75,7 +75,7 @@ describe('useValidateArrayInput custom hook', () => {
     validateOnBlurMock.mockReturnValue({ isValid: true, errorMessage: '' });
 
     const { result } = renderHook(() =>
-      useValidateArrayInput({
+      useValidateInputs({
         initValue: ['123', '456'],
         validateOnChange: validateOnChangeMock,
         validateOnBlurAll: validateOnBlurMock,
@@ -98,7 +98,7 @@ describe('useValidateArrayInput custom hook', () => {
     });
 
     const { result } = renderHook(() =>
-      useValidateArrayInput({
+      useValidateInputs({
         initValue: ['123', '12'],
         validateOnChange: validateOnChangeMock,
         validateOnBlurAll: validateOnBlurMock,

--- a/hooks/src/lib/useValidateInputs/useValidateInputs.ts
+++ b/hooks/src/lib/useValidateInputs/useValidateInputs.ts
@@ -11,7 +11,7 @@ export interface ValidateResult {
   errorMessage: string;
 }
 
-const useValidateArrayInput = ({
+const useValidateInputs = ({
   initValue,
   validateOnChange,
   validateOnBlurAll,
@@ -83,4 +83,4 @@ const useValidateArrayInput = ({
     onFocusHandler,
   };
 };
-export default useValidateArrayInput;
+export default useValidateInputs;

--- a/hooks/src/lib/utils/judgeCardBrand.ts
+++ b/hooks/src/lib/utils/judgeCardBrand.ts
@@ -1,7 +1,7 @@
-import { CARD_BRAND, CARD_BRAND_TYPE } from '../constants/cardBrand';
+import { CARD_BRAND, CardBrandType } from '../constants/cardBrand';
 
 export const judgeCardBrand = (cardNumber: string) => {
-  const cardBrandList = Object.keys(CARD_BRAND) as CARD_BRAND_TYPE[];
+  const cardBrandList = Object.keys(CARD_BRAND) as CardBrandType[];
   const cardBrand =
     cardBrandList.find((cardBrand) =>
       CARD_BRAND[cardBrand].condition.test(cardNumber),

--- a/hooks/src/lib/utils/judgeCardBrand.ts
+++ b/hooks/src/lib/utils/judgeCardBrand.ts
@@ -1,0 +1,11 @@
+import { CARD_BRAND, CARD_BRAND_TYPE } from '../constants/cardBrand';
+
+export const judgeCardBrand = (cardNumber: string) => {
+  const cardBrandList = Object.keys(CARD_BRAND) as CARD_BRAND_TYPE[];
+  const cardBrand =
+    cardBrandList.find((cardBrand) =>
+      CARD_BRAND[cardBrand].condition.test(cardNumber),
+    ) || 'NONE';
+
+  return CARD_BRAND[cardBrand];
+};

--- a/hooks/src/lib/utils/splitByLengthList.ts
+++ b/hooks/src/lib/utils/splitByLengthList.ts
@@ -1,0 +1,27 @@
+const splitByLengthList = (string: string, lengthList: number[]) => {
+  if (!lengthList.length) {
+    return [string];
+  }
+
+  const result: string[] = [];
+  let startIndex = 0;
+
+  for (const length of lengthList) {
+    const endIndex = startIndex + length;
+    const substring = string.slice(startIndex, endIndex);
+    result.push(substring);
+    startIndex = endIndex;
+
+    if (startIndex >= string.length) {
+      break;
+    }
+  }
+
+  if (startIndex < string.length) {
+    result.push(string.slice(startIndex));
+  }
+
+  return result;
+};
+
+export default splitByLengthList;

--- a/hooks/tsconfig.json
+++ b/hooks/tsconfig.json
@@ -5,6 +5,8 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
안녕하세요, 하루💙! 잘 지내셨나요? 6기 FE 헤인입니다.☺️
고민이 많아 변경사항에 비해 시간이 오래 걸린 것 같습니다ㅠㅠ 

---
## 📍 배포 주소
[🎀 components 스토리북 배포 주소](https://6638ad0a3b7cb5cd9e5e2fde-svhcxpkhnw.chromatic.com/?path=/docs/button--docs)
[💚 모달 컴포넌트 모듈 `hain-tain-components`](https://www.npmjs.com/package/hain-tain-components)
[💜 페이먼츠 모듈 `hain-tain-hooks`](https://www.npmjs.com/package/hain-tain-hooks)

---
## 🎯 2단계 주요 요구사항
[ 모달 컴포넌트 ]
- 다양한 모달 종류를 대응 가능하게 구현
  - 확인(Alert) 모달: 사용자에게 메시지를 전달하고 확인 버튼만 제공
  - 확인/취소(Confirm) 모달: 사용자에게 선택지를 제공하고 확인 및 취소 버튼 제공
  - 입력(Prompt) 모달: 사용자로부터 입력값을 받을 수 있는 입력 필드와 확인/취소 버튼 제공
- 모달 크기 옵션 추가
  - small, medium, large 등의 크기 옵션을 prop으로 전달받아 모달 크기 조절

[ 페이먼츠 커스텀 훅 ]
- 다양한 카드 브랜드 지원 확장
  - Visa, Mastercard, AMEX, Diners, UnionPay 등의 주요 카드사 식별 및 유효성 검사 로직 추가
  - 카드 브랜드별 식별 번호 및 카드 번호 유효성 검사 구현
- 카드 번호 포맷팅 기능 추가
  - 사용자 입력 시 자동으로 카드사별 규칙에 맞게 카드 번호를 구분하여 표시
  - 카드사별 포맷팅 규칙 적용
---
## 🤔 고민했던 점 및 질문
### 1. 카드 브랜드, 상태로 관리해야 할까?
- 2단계에서 새롭게 추가된 주요 요구사항은 `Visa`, `Mastercard`, `AMEX`, `Diners`, `UnionPay`와 같이 카드 번호에 따라 카드 브랜드를 구분하고, 카드 브랜드에 따라 포멧팅을 하는 것이었습니다. 따라서 카드 번호에 따라 카드 브랜드를 식별하는 로직이 필요했고, 당연하게도 식별한 카드 브랜드를 함께 사용자에게 제공해야 했습니다.
- [리엑트 공식문서](https://ko.react.dev/learn/thinking-in-react#step-3-find-the-minimal-but-complete-representation-of-ui-state)에서 컴포넌트 안의 다른 state를 가지고 계산이 가능하다면 state로 관리할 필요가 없다는 글을 보았습니다. 저는 카드 브랜드는 카드 번호(state)로 계산 가능하다고 생각하여 별도의 상태로 만들지 않고 구현하게 되었습니다.
  >컴포넌트 안의 다른 state나 props를 가지고 계산 가능한가요? 그렇다면 절대로 state가 아닙니다!
- 그런데 한편으로는 카드 번호를 이용하기 위해 `useCardNumber`에서 한꺼번에 너무 많은 것들을 관리하고 있는 것은 아닐까 고민이 되었습니다. 카드 브랜드를 별도의 상태로 만들고, `useCardBrand`와 같은 훅을 이용하여 관리해주는 것이 더 좋았을까? 그런데, 카드 브랜드는 상태로 굳이 관리될 필요가 없는 친구이지 않나? 라는 생각이 계속 반복되었습니다. 결국 상태로 관리하고 싶지 않다는 마음이 더 커서 현재 상태를 유지하게 되었습니다.

### 2. 모달, 현재처럼 props 로 받는 방식 vs 합성 컴포넌트 방식
- 모달을 사용하는 입장에서 어떤 방식이 더 편하게 사용할 수 있을지 고민이 되었습니다. `props 로 받는 방식`의 경우에는 반드시 넣어야하는 필수 프로퍼티를 제외하고는 default 값이 있기 때문에 하나의 태그안에 원하는 프로퍼티만 넣어서 편하게 만들 수 있다는 장점이 있다고 생각하였습니다. 반면, 옵션을 많이 지정하기 위해서는 props가 길어지게 되고, 각각의 props가 어디에 어떻게 필요한 것인지 단번에 파악하기 어렵다는 단점이 있다고 생각하였습니다.
- 반면, `합성 컴포넌트 방식`의 경우에는 자유롭게 모달 내부의 레이아웃을 구성할 수 있고, 무엇보다 관심사 분리가 보다 명확하게 되어 각각의 props를 넣어줄 수 있다는 장점이 있다고 생각하였습니다. 반면, 정말 간단한 모달을 만들고 싶어도, `ModalHeader`, `ModalBody`, `ModalFooter` 등 내부를 모두 지정해주어야 한다는 단점이 있다고 생각하였습니다.
- 저는 두 방식 중, props가 많더라도 하나의 태그로 편리하게 모달을 생성할 수 있게 해주는 것이 모듈을 사용하는 사람들에게 더 편하고 쉬운 경험을 제공할 수 있다고 생각하여 props 를 주는 방식으로 개발하게 되었습니다. 그런데 요구사항이 점점 늘어나면서 props가 지나치게 많아지자 오히려 더 불편해졌다는 생각이 들기 시작하였습니다.
- 프로그래밍 세계에 정답은 없지만, 컴포넌트 라이브러리로서 어떤 경험을 제공하는 것이 더 좋을지 고민이 많이 됩니다. 저의 고민에 대해 하루가 조언해주실 부분이 있으실까요?

- props 로 받는 방식
  ```js
   <Modal
        isOpened={isOpened}
        closeModal={handelModalClose}
        title="제목"
        primaryButton={{
          text: '확인',
          onClick: () => {
            alert('확인');
          },
        }}
        secondaryButton={{
          text: '닫기',
          onClick: handelModalClose,
        }}
      />
  ```
- 합성 컴포넌트 방식
  ```js
    <Modal>
      <Modal.ModalHeader>
      {...}
      </Modal.ModalHeader>
      </Modal.ModalBody>
      {...}
      </Modal.ModalBody>
      <Modal.ModalFooter>
      {...}
      </Modal.ModalFooter>
  </Modal>
  ```

### 3. 만약, 개발을 처음 배우는 사람이 처음 이 모듈을 접했다면, 어떤 점이 헷갈리고 실수하기 쉬울까?
- 이번 미션은 이것을 쓰는 사람들이 존재한다고 가정하고 구현을 해보았습니다. 그러므로 제가 가장 신경쓴 점은 `다른 사람들이 이해하기 쉽고, 쓰기 쉽게 만들자!` 였습니다. (모듈인만큼 UX 뿐만 아니라 DX 측면에서도 좋은 경험을 제공하고 싶었습니다.) 이를 위해 스토리북에 docs 및 viewport도 추가하고, npm docs 도 상세하게 작성하기 위해 노력하였습니다. 그러나 여전히 부족한 점이 많으리라 생각됩니다.
- 특히, IT에 대해 잘 모르거나, 개발을 처음 배우는 사람이 이 모듈을 사용하려고 한다면, 어떤 점이 개선되면 더 쉽게 이 모듈을 사용할 수 있을까요? 이 모듈을 사용해야 한다면, 어떤 점이 가장 불편하게 느껴질까요? 다음 단계에서 개선할 수 있도록 새롭고 환기된 시각으로 바라봐주시면 감사하겠습니다.
---
+) 현재 `useCardNumber` 에서 `formattingValue`을 input value 로 사용할 경우, 카드 번호의 중간 부분을 바꿔도 커서가 맨 뒤로 이동한다는 문제가 있습니다. UX 적으로 몹시 좋지 않다고 생각하지만, 이를 고치기엔 시간이 많이 걸릴 것 같고, 일단 기능요구사항은 충족하였기에 우선적으로 리뷰요청 보냅니다. 추후 시간이 되면 구현해보도록 하겠습니다.
감사합니다🙏